### PR TITLE
chore: update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"polyfill"
 	],
 	"dependencies": {
-		"modern-node-polyfills": "^0.1.3"
+		"modern-node-polyfills": "^1.0.0"
 	},
 	"devDependencies": {
 		"@commitlint/cli": "^17.6.5",
@@ -43,7 +43,7 @@
 		"@favware/cliff-jumper": "^2.1.0",
 		"@favware/npm-deprecate": "^1.0.7",
 		"cz-conventional-changelog": "^3.3.0",
-		"esbuild": "^0.18.0",
+		"esbuild": "^0.18.1",
 		"eslint": "^8.42.0",
 		"eslint-config-mahir": "^0.0.26",
 		"husky": "^8.0.3",
@@ -53,6 +53,9 @@
 		"tsup": "^6.7.0",
 		"typescript": "^5.1.3",
 		"vitest": "^0.32.0"
+	},
+	"peerDependencies": {
+		"esbuild": "^0.14.0 || ^0.15.0 || ^0.16.0 || ^0.17.0 || ^0.18.0"
 	},
 	"files": [
 		"dist/**/*.js*",
@@ -84,5 +87,8 @@
 		"ansi-regex": "^5.0.1",
 		"minimist": "^1.2.8"
 	},
-	"packageManager": "yarn@3.6.0"
+	"packageManager": "yarn@3.6.0",
+	"engines": {
+		"node": ">=14.0.0"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"@favware/cliff-jumper": "^2.1.0",
 		"@favware/npm-deprecate": "^1.0.7",
 		"cz-conventional-changelog": "^3.3.0",
-		"esbuild": "^0.18.1",
+		"esbuild": "^0.18.2",
 		"eslint": "^8.42.0",
 		"eslint-config-mahir": "^0.0.26",
 		"husky": "^8.0.3",

--- a/tests/scenarios/__snapshots__/directEval.test.ts.snap
+++ b/tests/scenarios/__snapshots__/directEval.test.ts.snap
@@ -3206,7 +3206,8 @@ exports[`Direct Eval Test > GIVEN a file that imports a crypto THEN the output s
       if (first === void 0 || last === void 0) {
         boundsError(offset, this.length - 8);
       }
-      const val = (first << 24) + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 8 + this[++offset];
+      const val = (first << 24) + // Overflow
+      this[++offset] * 2 ** 16 + this[++offset] * 2 ** 8 + this[++offset];
       return (BigInt(val) << BigInt(32)) + BigInt(this[++offset] * 2 ** 24 + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 8 + last);
     });
     Buffer.prototype.readFloatLE = function readFloatLE(offset, noAssert) {
@@ -4018,6 +4019,7 @@ exports[`Direct Eval Test > GIVEN a file that imports a crypto THEN the output s
           }
           return ret;
         }
+        // Consumes a specified amount of bytes or characters from the buffered data.
       }, {
         key: \\"consume\\",
         value: function consume(n6, hasStrings) {
@@ -4037,6 +4039,7 @@ exports[`Direct Eval Test > GIVEN a file that imports a crypto THEN the output s
         value: function first() {
           return this.head.data;
         }
+        // Consumes a specified amount of characters from the buffered data.
       }, {
         key: \\"_getString\\",
         value: function _getString(n6) {
@@ -4070,6 +4073,7 @@ exports[`Direct Eval Test > GIVEN a file that imports a crypto THEN the output s
           this.length -= c6;
           return ret;
         }
+        // Consumes a specified amount of bytes from the buffered data.
       }, {
         key: \\"_getBuffer\\",
         value: function _getBuffer(n6) {
@@ -4101,11 +4105,14 @@ exports[`Direct Eval Test > GIVEN a file that imports a crypto THEN the output s
           this.length -= c6;
           return ret;
         }
+        // Make sure the linked list only shows the minimal necessary information.
       }, {
         key: custom,
         value: function value(_4, options) {
           return inspect2(this, _objectSpread({}, options, {
+            // Only inspect one level.
             depth: 0,
+            // It should not recurse.
             customInspect: false
           }));
         }
@@ -4577,6 +4584,9 @@ exports[`Direct Eval Test > GIVEN a file that imports a crypto THEN the output s
       return this;
     };
     Object.defineProperty(Writable.prototype, \\"writableBuffer\\", {
+      // making it explicit this property is not enumerable
+      // because otherwise some prototype manipulation in
+      // userland will fail
       enumerable: false,
       get: function get() {
         return this._writableState && this._writableState.getBuffer();
@@ -4589,6 +4599,9 @@ exports[`Direct Eval Test > GIVEN a file that imports a crypto THEN the output s
       return chunk;
     }
     Object.defineProperty(Writable.prototype, \\"writableHighWaterMark\\", {
+      // making it explicit this property is not enumerable
+      // because otherwise some prototype manipulation in
+      // userland will fail
       enumerable: false,
       get: function get() {
         return this._writableState.highWaterMark;
@@ -4767,6 +4780,9 @@ exports[`Direct Eval Test > GIVEN a file that imports a crypto THEN the output s
       return this;
     };
     Object.defineProperty(Writable.prototype, \\"writableLength\\", {
+      // making it explicit this property is not enumerable
+      // because otherwise some prototype manipulation in
+      // userland will fail
       enumerable: false,
       get: function get() {
         return this._writableState.length;
@@ -4839,6 +4855,9 @@ exports[`Direct Eval Test > GIVEN a file that imports a crypto THEN the output s
       state.corkedRequestsFree.next = corkReq;
     }
     Object.defineProperty(Writable.prototype, \\"destroyed\\", {
+      // making it explicit this property is not enumerable
+      // because otherwise some prototype manipulation in
+      // userland will fail
       enumerable: false,
       get: function get() {
         if (this._writableState === void 0) {
@@ -4904,18 +4923,27 @@ exports[`Direct Eval Test > GIVEN a file that imports a crypto THEN the output s
       }
     }
     Object.defineProperty(Duplex.prototype, \\"writableHighWaterMark\\", {
+      // making it explicit this property is not enumerable
+      // because otherwise some prototype manipulation in
+      // userland will fail
       enumerable: false,
       get: function get() {
         return this._writableState.highWaterMark;
       }
     });
     Object.defineProperty(Duplex.prototype, \\"writableBuffer\\", {
+      // making it explicit this property is not enumerable
+      // because otherwise some prototype manipulation in
+      // userland will fail
       enumerable: false,
       get: function get() {
         return this._writableState && this._writableState.getBuffer();
       }
     });
     Object.defineProperty(Duplex.prototype, \\"writableLength\\", {
+      // making it explicit this property is not enumerable
+      // because otherwise some prototype manipulation in
+      // userland will fail
       enumerable: false,
       get: function get() {
         return this._writableState.length;
@@ -4930,6 +4958,9 @@ exports[`Direct Eval Test > GIVEN a file that imports a crypto THEN the output s
       self2.end();
     }
     Object.defineProperty(Duplex.prototype, \\"destroyed\\", {
+      // making it explicit this property is not enumerable
+      // because otherwise some prototype manipulation in
+      // userland will fail
       enumerable: false,
       get: function get() {
         if (this._readableState === void 0 || this._writableState === void 0) {
@@ -5342,6 +5373,9 @@ exports[`Direct Eval Test > GIVEN a file that imports a crypto THEN the output s
       Stream.call(this);
     }
     Object.defineProperty(Readable.prototype, \\"destroyed\\", {
+      // making it explicit this property is not enumerable
+      // because otherwise some prototype manipulation in
+      // userland will fail
       enumerable: false,
       get: function get() {
         if (this._readableState === void 0) {
@@ -5928,18 +5962,27 @@ exports[`Direct Eval Test > GIVEN a file that imports a crypto THEN the output s
       };
     }
     Object.defineProperty(Readable.prototype, \\"readableHighWaterMark\\", {
+      // making it explicit this property is not enumerable
+      // because otherwise some prototype manipulation in
+      // userland will fail
       enumerable: false,
       get: function get() {
         return this._readableState.highWaterMark;
       }
     });
     Object.defineProperty(Readable.prototype, \\"readableBuffer\\", {
+      // making it explicit this property is not enumerable
+      // because otherwise some prototype manipulation in
+      // userland will fail
       enumerable: false,
       get: function get() {
         return this._readableState && this._readableState.buffer;
       }
     });
     Object.defineProperty(Readable.prototype, \\"readableFlowing\\", {
+      // making it explicit this property is not enumerable
+      // because otherwise some prototype manipulation in
+      // userland will fail
       enumerable: false,
       get: function get() {
         return this._readableState.flowing;
@@ -5952,6 +5995,9 @@ exports[`Direct Eval Test > GIVEN a file that imports a crypto THEN the output s
     });
     Readable._fromList = fromList;
     Object.defineProperty(Readable.prototype, \\"readableLength\\", {
+      // making it explicit this property is not enumerable
+      // because otherwise some prototype manipulation in
+      // userland will fail
       enumerable: false,
       get: function get() {
         return this._readableState.length;
@@ -7571,6 +7617,7 @@ exports[`Direct Eval Test > GIVEN a file that imports a crypto THEN the output s
           }
           return ret;
         }
+        // Consumes a specified amount of bytes or characters from the buffered data.
       }, {
         key: \\"consume\\",
         value: function consume(n6, hasStrings) {
@@ -7590,6 +7637,7 @@ exports[`Direct Eval Test > GIVEN a file that imports a crypto THEN the output s
         value: function first() {
           return this.head.data;
         }
+        // Consumes a specified amount of characters from the buffered data.
       }, {
         key: \\"_getString\\",
         value: function _getString(n6) {
@@ -7623,6 +7671,7 @@ exports[`Direct Eval Test > GIVEN a file that imports a crypto THEN the output s
           this.length -= c6;
           return ret;
         }
+        // Consumes a specified amount of bytes from the buffered data.
       }, {
         key: \\"_getBuffer\\",
         value: function _getBuffer(n6) {
@@ -7654,11 +7703,14 @@ exports[`Direct Eval Test > GIVEN a file that imports a crypto THEN the output s
           this.length -= c6;
           return ret;
         }
+        // Make sure the linked list only shows the minimal necessary information.
       }, {
         key: custom,
         value: function value(_4, options) {
           return inspect2(this, _objectSpread({}, options, {
+            // Only inspect one level.
             depth: 0,
+            // It should not recurse.
             customInspect: false
           }));
         }
@@ -8130,6 +8182,9 @@ exports[`Direct Eval Test > GIVEN a file that imports a crypto THEN the output s
       return this;
     };
     Object.defineProperty(Writable.prototype, \\"writableBuffer\\", {
+      // making it explicit this property is not enumerable
+      // because otherwise some prototype manipulation in
+      // userland will fail
       enumerable: false,
       get: function get() {
         return this._writableState && this._writableState.getBuffer();
@@ -8142,6 +8197,9 @@ exports[`Direct Eval Test > GIVEN a file that imports a crypto THEN the output s
       return chunk;
     }
     Object.defineProperty(Writable.prototype, \\"writableHighWaterMark\\", {
+      // making it explicit this property is not enumerable
+      // because otherwise some prototype manipulation in
+      // userland will fail
       enumerable: false,
       get: function get() {
         return this._writableState.highWaterMark;
@@ -8320,6 +8378,9 @@ exports[`Direct Eval Test > GIVEN a file that imports a crypto THEN the output s
       return this;
     };
     Object.defineProperty(Writable.prototype, \\"writableLength\\", {
+      // making it explicit this property is not enumerable
+      // because otherwise some prototype manipulation in
+      // userland will fail
       enumerable: false,
       get: function get() {
         return this._writableState.length;
@@ -8392,6 +8453,9 @@ exports[`Direct Eval Test > GIVEN a file that imports a crypto THEN the output s
       state.corkedRequestsFree.next = corkReq;
     }
     Object.defineProperty(Writable.prototype, \\"destroyed\\", {
+      // making it explicit this property is not enumerable
+      // because otherwise some prototype manipulation in
+      // userland will fail
       enumerable: false,
       get: function get() {
         if (this._writableState === void 0) {
@@ -8457,18 +8521,27 @@ exports[`Direct Eval Test > GIVEN a file that imports a crypto THEN the output s
       }
     }
     Object.defineProperty(Duplex.prototype, \\"writableHighWaterMark\\", {
+      // making it explicit this property is not enumerable
+      // because otherwise some prototype manipulation in
+      // userland will fail
       enumerable: false,
       get: function get() {
         return this._writableState.highWaterMark;
       }
     });
     Object.defineProperty(Duplex.prototype, \\"writableBuffer\\", {
+      // making it explicit this property is not enumerable
+      // because otherwise some prototype manipulation in
+      // userland will fail
       enumerable: false,
       get: function get() {
         return this._writableState && this._writableState.getBuffer();
       }
     });
     Object.defineProperty(Duplex.prototype, \\"writableLength\\", {
+      // making it explicit this property is not enumerable
+      // because otherwise some prototype manipulation in
+      // userland will fail
       enumerable: false,
       get: function get() {
         return this._writableState.length;
@@ -8483,6 +8556,9 @@ exports[`Direct Eval Test > GIVEN a file that imports a crypto THEN the output s
       self2.end();
     }
     Object.defineProperty(Duplex.prototype, \\"destroyed\\", {
+      // making it explicit this property is not enumerable
+      // because otherwise some prototype manipulation in
+      // userland will fail
       enumerable: false,
       get: function get() {
         if (this._readableState === void 0 || this._writableState === void 0) {
@@ -8895,6 +8971,9 @@ exports[`Direct Eval Test > GIVEN a file that imports a crypto THEN the output s
       Stream.call(this);
     }
     Object.defineProperty(Readable.prototype, \\"destroyed\\", {
+      // making it explicit this property is not enumerable
+      // because otherwise some prototype manipulation in
+      // userland will fail
       enumerable: false,
       get: function get() {
         if (this._readableState === void 0) {
@@ -9481,18 +9560,27 @@ exports[`Direct Eval Test > GIVEN a file that imports a crypto THEN the output s
       };
     }
     Object.defineProperty(Readable.prototype, \\"readableHighWaterMark\\", {
+      // making it explicit this property is not enumerable
+      // because otherwise some prototype manipulation in
+      // userland will fail
       enumerable: false,
       get: function get() {
         return this._readableState.highWaterMark;
       }
     });
     Object.defineProperty(Readable.prototype, \\"readableBuffer\\", {
+      // making it explicit this property is not enumerable
+      // because otherwise some prototype manipulation in
+      // userland will fail
       enumerable: false,
       get: function get() {
         return this._readableState && this._readableState.buffer;
       }
     });
     Object.defineProperty(Readable.prototype, \\"readableFlowing\\", {
+      // making it explicit this property is not enumerable
+      // because otherwise some prototype manipulation in
+      // userland will fail
       enumerable: false,
       get: function get() {
         return this._readableState.flowing;
@@ -9505,6 +9593,9 @@ exports[`Direct Eval Test > GIVEN a file that imports a crypto THEN the output s
     });
     Readable._fromList = fromList;
     Object.defineProperty(Readable.prototype, \\"readableLength\\", {
+      // making it explicit this property is not enumerable
+      // because otherwise some prototype manipulation in
+      // userland will fail
       enumerable: false,
       get: function get() {
         return this._readableState.length;
@@ -10679,6 +10770,7 @@ exports[`Direct Eval Test > GIVEN a file that imports a crypto THEN the output s
       return num << shift & 268435455 | num >>> 28 - shift;
     };
     var pc2table = [
+      // inL => outL
       14,
       11,
       17,
@@ -10703,6 +10795,7 @@ exports[`Direct Eval Test > GIVEN a file that imports a crypto THEN the output s
       8,
       15,
       26,
+      // inR => outR
       15,
       4,
       25,
@@ -21521,6 +21614,7 @@ exports[`Direct Eval Test > GIVEN a file that imports a crypto THEN the output s
       return num << shift & 268435455 | num >>> 28 - shift;
     };
     var pc2table = [
+      // inL => outL
       14,
       11,
       17,
@@ -21545,6 +21639,7 @@ exports[`Direct Eval Test > GIVEN a file that imports a crypto THEN the output s
       8,
       15,
       26,
+      // inR => outR
       15,
       4,
       25,
@@ -40517,9 +40612,13 @@ exports[`Direct Eval Test > GIVEN a file that imports a crypto THEN the output s
         }
         var comb = [
           points[a6],
+          /* 1 */
           null,
+          /* 3 */
           null,
+          /* 5 */
           points[b4]
+          /* 7 */
         ];
         if (points[a6].y.cmp(points[b4].y) === 0) {
           comb[1] = points[a6].add(points[b4]);
@@ -40533,14 +40632,23 @@ exports[`Direct Eval Test > GIVEN a file that imports a crypto THEN the output s
         }
         var index = [
           -3,
+          /* -1 -1 */
           -1,
+          /* -1 0 */
           -5,
+          /* -1 1 */
           -7,
+          /* 0 -1 */
           0,
+          /* 0 0 */
           7,
+          /* 0 1 */
           5,
+          /* 1 -1 */
           1,
+          /* 1 0 */
           3
+          /* 1 1 */
         ];
         var jsf = getJSF(coeffs[a6], coeffs[b4]);
         max = Math.max(jsf[0].length, max);
@@ -42473,12 +42581,14 @@ exports[`Direct Eval Test > GIVEN a file that imports a crypto THEN the output s
       p: \\"7fffffffffffffff ffffffffffffffff ffffffffffffffff ffffffffffffffed\\",
       a: \\"-1\\",
       c: \\"1\\",
+      // -121665 * (121666^(-1)) (mod P)
       d: \\"52036cee2b6ffe73 8cc740797779e898 00700a4d4141d8ab 75eb4dca135978a3\\",
       n: \\"1000000000000000 0000000000000000 14def9dea2f79cd6 5812631a5cf5d3ed\\",
       hash: hash.sha256,
       gRed: false,
       g: [
         \\"216936d3cd6e53fec0a4e231fdd6dc5c692cc7609525a7b2c9562d608f25d51a\\",
+        // 4/5
         \\"6666666666666666666666666666666666666666666666666666666666666658\\"
       ]
     });
@@ -42497,6 +42607,7 @@ exports[`Direct Eval Test > GIVEN a file that imports a crypto THEN the output s
       n: \\"ffffffff ffffffff ffffffff fffffffe baaedce6 af48a03b bfd25e8c d0364141\\",
       h: \\"1\\",
       hash: hash.sha256,
+      // Precomputed endomorphism
       beta: \\"7ae96a2b657c07106e64479eac3434e99cf0497512f58995c1396c28719501ee\\",
       lambda: \\"5363ad4cc05c30e0a5261c028812645a122e22ea20816678df02967c1b23bd72\\",
       basis: [{
@@ -60470,9 +60581,13 @@ exports[`Direct Eval Test > GIVEN a file that imports a crypto THEN the output s
         }
         var comb = [
           points[a6],
+          /* 1 */
           null,
+          /* 3 */
           null,
+          /* 5 */
           points[b4]
+          /* 7 */
         ];
         if (points[a6].y.cmp(points[b4].y) === 0) {
           comb[1] = points[a6].add(points[b4]);
@@ -60486,14 +60601,23 @@ exports[`Direct Eval Test > GIVEN a file that imports a crypto THEN the output s
         }
         var index = [
           -3,
+          /* -1 -1 */
           -1,
+          /* -1 0 */
           -5,
+          /* -1 1 */
           -7,
+          /* 0 -1 */
           0,
+          /* 0 0 */
           7,
+          /* 0 1 */
           5,
+          /* 1 -1 */
           1,
+          /* 1 0 */
           3
+          /* 1 1 */
         ];
         var jsf = getJSF(coeffs[a6], coeffs[b4]);
         max = Math.max(jsf[0].length, max);
@@ -62426,12 +62550,14 @@ exports[`Direct Eval Test > GIVEN a file that imports a crypto THEN the output s
       p: \\"7fffffffffffffff ffffffffffffffff ffffffffffffffff ffffffffffffffed\\",
       a: \\"-1\\",
       c: \\"1\\",
+      // -121665 * (121666^(-1)) (mod P)
       d: \\"52036cee2b6ffe73 8cc740797779e898 00700a4d4141d8ab 75eb4dca135978a3\\",
       n: \\"1000000000000000 0000000000000000 14def9dea2f79cd6 5812631a5cf5d3ed\\",
       hash: hash.sha256,
       gRed: false,
       g: [
         \\"216936d3cd6e53fec0a4e231fdd6dc5c692cc7609525a7b2c9562d608f25d51a\\",
+        // 4/5
         \\"6666666666666666666666666666666666666666666666666666666666666658\\"
       ]
     });
@@ -62450,6 +62576,7 @@ exports[`Direct Eval Test > GIVEN a file that imports a crypto THEN the output s
       n: \\"ffffffff ffffffff ffffffff fffffffe baaedce6 af48a03b bfd25e8c d0364141\\",
       h: \\"1\\",
       hash: hash.sha256,
+      // Precomputed endomorphism
       beta: \\"7ae96a2b657c07106e64479eac3434e99cf0497512f58995c1396c28719501ee\\",
       lambda: \\"5363ad4cc05c30e0a5261c028812645a122e22ea20816678df02967c1b23bd72\\",
       basis: [{
@@ -74146,7 +74273,13 @@ exports[`Direct Eval Test > GIVEN a file that imports a crypto THEN the output s
   var result = getHashes();
   console.log(result);
 })();
-/*! ieee754. BSD-3-Clause License. Feross Aboukhadijeh <https://feross.org/opensource> */
-/*! safe-buffer. MIT License. Feross Aboukhadijeh <https://feross.org/opensource> */
+/*! Bundled license information:
+
+@jspm/core/nodelibs/browser/chunk-44e51b61.js:
+  (*! ieee754. BSD-3-Clause License. Feross Aboukhadijeh <https://feross.org/opensource> *)
+
+@jspm/core/nodelibs/browser/crypto.js:
+  (*! safe-buffer. MIT License. Feross Aboukhadijeh <https://feross.org/opensource> *)
+*/
 "
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -256,9 +256,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/android-arm64@npm:0.18.1":
-  version: 0.18.1
-  resolution: "@esbuild/android-arm64@npm:0.18.1"
+"@esbuild/android-arm64@npm:0.18.2":
+  version: 0.18.2
+  resolution: "@esbuild/android-arm64@npm:0.18.2"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -270,9 +270,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/android-arm@npm:0.18.1":
-  version: 0.18.1
-  resolution: "@esbuild/android-arm@npm:0.18.1"
+"@esbuild/android-arm@npm:0.18.2":
+  version: 0.18.2
+  resolution: "@esbuild/android-arm@npm:0.18.2"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/android-x64@npm:0.18.1":
-  version: 0.18.1
-  resolution: "@esbuild/android-x64@npm:0.18.1"
+"@esbuild/android-x64@npm:0.18.2":
+  version: 0.18.2
+  resolution: "@esbuild/android-x64@npm:0.18.2"
   conditions: os=android & cpu=x64
   languageName: node
   linkType: hard
@@ -298,9 +298,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/darwin-arm64@npm:0.18.1":
-  version: 0.18.1
-  resolution: "@esbuild/darwin-arm64@npm:0.18.1"
+"@esbuild/darwin-arm64@npm:0.18.2":
+  version: 0.18.2
+  resolution: "@esbuild/darwin-arm64@npm:0.18.2"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
@@ -312,9 +312,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/darwin-x64@npm:0.18.1":
-  version: 0.18.1
-  resolution: "@esbuild/darwin-x64@npm:0.18.1"
+"@esbuild/darwin-x64@npm:0.18.2":
+  version: 0.18.2
+  resolution: "@esbuild/darwin-x64@npm:0.18.2"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -326,9 +326,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/freebsd-arm64@npm:0.18.1":
-  version: 0.18.1
-  resolution: "@esbuild/freebsd-arm64@npm:0.18.1"
+"@esbuild/freebsd-arm64@npm:0.18.2":
+  version: 0.18.2
+  resolution: "@esbuild/freebsd-arm64@npm:0.18.2"
   conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
@@ -340,9 +340,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/freebsd-x64@npm:0.18.1":
-  version: 0.18.1
-  resolution: "@esbuild/freebsd-x64@npm:0.18.1"
+"@esbuild/freebsd-x64@npm:0.18.2":
+  version: 0.18.2
+  resolution: "@esbuild/freebsd-x64@npm:0.18.2"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -354,9 +354,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-arm64@npm:0.18.1":
-  version: 0.18.1
-  resolution: "@esbuild/linux-arm64@npm:0.18.1"
+"@esbuild/linux-arm64@npm:0.18.2":
+  version: 0.18.2
+  resolution: "@esbuild/linux-arm64@npm:0.18.2"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
@@ -368,9 +368,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-arm@npm:0.18.1":
-  version: 0.18.1
-  resolution: "@esbuild/linux-arm@npm:0.18.1"
+"@esbuild/linux-arm@npm:0.18.2":
+  version: 0.18.2
+  resolution: "@esbuild/linux-arm@npm:0.18.2"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
@@ -382,9 +382,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-ia32@npm:0.18.1":
-  version: 0.18.1
-  resolution: "@esbuild/linux-ia32@npm:0.18.1"
+"@esbuild/linux-ia32@npm:0.18.2":
+  version: 0.18.2
+  resolution: "@esbuild/linux-ia32@npm:0.18.2"
   conditions: os=linux & cpu=ia32
   languageName: node
   linkType: hard
@@ -396,9 +396,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-loong64@npm:0.18.1":
-  version: 0.18.1
-  resolution: "@esbuild/linux-loong64@npm:0.18.1"
+"@esbuild/linux-loong64@npm:0.18.2":
+  version: 0.18.2
+  resolution: "@esbuild/linux-loong64@npm:0.18.2"
   conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
@@ -410,9 +410,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-mips64el@npm:0.18.1":
-  version: 0.18.1
-  resolution: "@esbuild/linux-mips64el@npm:0.18.1"
+"@esbuild/linux-mips64el@npm:0.18.2":
+  version: 0.18.2
+  resolution: "@esbuild/linux-mips64el@npm:0.18.2"
   conditions: os=linux & cpu=mips64el
   languageName: node
   linkType: hard
@@ -424,9 +424,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-ppc64@npm:0.18.1":
-  version: 0.18.1
-  resolution: "@esbuild/linux-ppc64@npm:0.18.1"
+"@esbuild/linux-ppc64@npm:0.18.2":
+  version: 0.18.2
+  resolution: "@esbuild/linux-ppc64@npm:0.18.2"
   conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
@@ -438,9 +438,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-riscv64@npm:0.18.1":
-  version: 0.18.1
-  resolution: "@esbuild/linux-riscv64@npm:0.18.1"
+"@esbuild/linux-riscv64@npm:0.18.2":
+  version: 0.18.2
+  resolution: "@esbuild/linux-riscv64@npm:0.18.2"
   conditions: os=linux & cpu=riscv64
   languageName: node
   linkType: hard
@@ -452,9 +452,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-s390x@npm:0.18.1":
-  version: 0.18.1
-  resolution: "@esbuild/linux-s390x@npm:0.18.1"
+"@esbuild/linux-s390x@npm:0.18.2":
+  version: 0.18.2
+  resolution: "@esbuild/linux-s390x@npm:0.18.2"
   conditions: os=linux & cpu=s390x
   languageName: node
   linkType: hard
@@ -466,9 +466,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-x64@npm:0.18.1":
-  version: 0.18.1
-  resolution: "@esbuild/linux-x64@npm:0.18.1"
+"@esbuild/linux-x64@npm:0.18.2":
+  version: 0.18.2
+  resolution: "@esbuild/linux-x64@npm:0.18.2"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
@@ -480,9 +480,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/netbsd-x64@npm:0.18.1":
-  version: 0.18.1
-  resolution: "@esbuild/netbsd-x64@npm:0.18.1"
+"@esbuild/netbsd-x64@npm:0.18.2":
+  version: 0.18.2
+  resolution: "@esbuild/netbsd-x64@npm:0.18.2"
   conditions: os=netbsd & cpu=x64
   languageName: node
   linkType: hard
@@ -494,9 +494,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/openbsd-x64@npm:0.18.1":
-  version: 0.18.1
-  resolution: "@esbuild/openbsd-x64@npm:0.18.1"
+"@esbuild/openbsd-x64@npm:0.18.2":
+  version: 0.18.2
+  resolution: "@esbuild/openbsd-x64@npm:0.18.2"
   conditions: os=openbsd & cpu=x64
   languageName: node
   linkType: hard
@@ -508,9 +508,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/sunos-x64@npm:0.18.1":
-  version: 0.18.1
-  resolution: "@esbuild/sunos-x64@npm:0.18.1"
+"@esbuild/sunos-x64@npm:0.18.2":
+  version: 0.18.2
+  resolution: "@esbuild/sunos-x64@npm:0.18.2"
   conditions: os=sunos & cpu=x64
   languageName: node
   linkType: hard
@@ -522,9 +522,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/win32-arm64@npm:0.18.1":
-  version: 0.18.1
-  resolution: "@esbuild/win32-arm64@npm:0.18.1"
+"@esbuild/win32-arm64@npm:0.18.2":
+  version: 0.18.2
+  resolution: "@esbuild/win32-arm64@npm:0.18.2"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -536,9 +536,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/win32-ia32@npm:0.18.1":
-  version: 0.18.1
-  resolution: "@esbuild/win32-ia32@npm:0.18.1"
+"@esbuild/win32-ia32@npm:0.18.2":
+  version: 0.18.2
+  resolution: "@esbuild/win32-ia32@npm:0.18.2"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
@@ -550,9 +550,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/win32-x64@npm:0.18.1":
-  version: 0.18.1
-  resolution: "@esbuild/win32-x64@npm:0.18.1"
+"@esbuild/win32-x64@npm:0.18.2":
+  version: 0.18.2
+  resolution: "@esbuild/win32-x64@npm:0.18.2"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -2448,7 +2448,7 @@ __metadata:
     "@favware/cliff-jumper": ^2.1.0
     "@favware/npm-deprecate": ^1.0.7
     cz-conventional-changelog: ^3.3.0
-    esbuild: ^0.18.1
+    esbuild: ^0.18.2
     eslint: ^8.42.0
     eslint-config-mahir: ^0.0.26
     husky: ^8.0.3
@@ -2541,32 +2541,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:^0.18.1":
-  version: 0.18.1
-  resolution: "esbuild@npm:0.18.1"
+"esbuild@npm:^0.18.2":
+  version: 0.18.2
+  resolution: "esbuild@npm:0.18.2"
   dependencies:
-    "@esbuild/android-arm": 0.18.1
-    "@esbuild/android-arm64": 0.18.1
-    "@esbuild/android-x64": 0.18.1
-    "@esbuild/darwin-arm64": 0.18.1
-    "@esbuild/darwin-x64": 0.18.1
-    "@esbuild/freebsd-arm64": 0.18.1
-    "@esbuild/freebsd-x64": 0.18.1
-    "@esbuild/linux-arm": 0.18.1
-    "@esbuild/linux-arm64": 0.18.1
-    "@esbuild/linux-ia32": 0.18.1
-    "@esbuild/linux-loong64": 0.18.1
-    "@esbuild/linux-mips64el": 0.18.1
-    "@esbuild/linux-ppc64": 0.18.1
-    "@esbuild/linux-riscv64": 0.18.1
-    "@esbuild/linux-s390x": 0.18.1
-    "@esbuild/linux-x64": 0.18.1
-    "@esbuild/netbsd-x64": 0.18.1
-    "@esbuild/openbsd-x64": 0.18.1
-    "@esbuild/sunos-x64": 0.18.1
-    "@esbuild/win32-arm64": 0.18.1
-    "@esbuild/win32-ia32": 0.18.1
-    "@esbuild/win32-x64": 0.18.1
+    "@esbuild/android-arm": 0.18.2
+    "@esbuild/android-arm64": 0.18.2
+    "@esbuild/android-x64": 0.18.2
+    "@esbuild/darwin-arm64": 0.18.2
+    "@esbuild/darwin-x64": 0.18.2
+    "@esbuild/freebsd-arm64": 0.18.2
+    "@esbuild/freebsd-x64": 0.18.2
+    "@esbuild/linux-arm": 0.18.2
+    "@esbuild/linux-arm64": 0.18.2
+    "@esbuild/linux-ia32": 0.18.2
+    "@esbuild/linux-loong64": 0.18.2
+    "@esbuild/linux-mips64el": 0.18.2
+    "@esbuild/linux-ppc64": 0.18.2
+    "@esbuild/linux-riscv64": 0.18.2
+    "@esbuild/linux-s390x": 0.18.2
+    "@esbuild/linux-x64": 0.18.2
+    "@esbuild/netbsd-x64": 0.18.2
+    "@esbuild/openbsd-x64": 0.18.2
+    "@esbuild/sunos-x64": 0.18.2
+    "@esbuild/win32-arm64": 0.18.2
+    "@esbuild/win32-ia32": 0.18.2
+    "@esbuild/win32-x64": 0.18.2
   dependenciesMeta:
     "@esbuild/android-arm":
       optional: true
@@ -2614,7 +2614,7 @@ __metadata:
       optional: true
   bin:
     esbuild: bin/esbuild
-  checksum: e7431e93fd395483c76f20e7944c258999550f3efc69ae9b9e37f2e317fd5b3aac53da350d82e5c79ef53a677a8baacffe0c079e88efa3c01184f3b58c2682d7
+  checksum: 64d82cc5fa1280f1730f96fdb9a74a23effb01de63d020c99f9090ea792fe78199daf083e842eccd3a55ccbad3d1bafb2f4b86280b6c8ce203fa309f06312597
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -256,9 +256,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/android-arm64@npm:0.18.0":
-  version: 0.18.0
-  resolution: "@esbuild/android-arm64@npm:0.18.0"
+"@esbuild/android-arm64@npm:0.18.1":
+  version: 0.18.1
+  resolution: "@esbuild/android-arm64@npm:0.18.1"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -270,9 +270,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/android-arm@npm:0.18.0":
-  version: 0.18.0
-  resolution: "@esbuild/android-arm@npm:0.18.0"
+"@esbuild/android-arm@npm:0.18.1":
+  version: 0.18.1
+  resolution: "@esbuild/android-arm@npm:0.18.1"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/android-x64@npm:0.18.0":
-  version: 0.18.0
-  resolution: "@esbuild/android-x64@npm:0.18.0"
+"@esbuild/android-x64@npm:0.18.1":
+  version: 0.18.1
+  resolution: "@esbuild/android-x64@npm:0.18.1"
   conditions: os=android & cpu=x64
   languageName: node
   linkType: hard
@@ -298,9 +298,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/darwin-arm64@npm:0.18.0":
-  version: 0.18.0
-  resolution: "@esbuild/darwin-arm64@npm:0.18.0"
+"@esbuild/darwin-arm64@npm:0.18.1":
+  version: 0.18.1
+  resolution: "@esbuild/darwin-arm64@npm:0.18.1"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
@@ -312,9 +312,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/darwin-x64@npm:0.18.0":
-  version: 0.18.0
-  resolution: "@esbuild/darwin-x64@npm:0.18.0"
+"@esbuild/darwin-x64@npm:0.18.1":
+  version: 0.18.1
+  resolution: "@esbuild/darwin-x64@npm:0.18.1"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -326,9 +326,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/freebsd-arm64@npm:0.18.0":
-  version: 0.18.0
-  resolution: "@esbuild/freebsd-arm64@npm:0.18.0"
+"@esbuild/freebsd-arm64@npm:0.18.1":
+  version: 0.18.1
+  resolution: "@esbuild/freebsd-arm64@npm:0.18.1"
   conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
@@ -340,9 +340,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/freebsd-x64@npm:0.18.0":
-  version: 0.18.0
-  resolution: "@esbuild/freebsd-x64@npm:0.18.0"
+"@esbuild/freebsd-x64@npm:0.18.1":
+  version: 0.18.1
+  resolution: "@esbuild/freebsd-x64@npm:0.18.1"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -354,9 +354,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-arm64@npm:0.18.0":
-  version: 0.18.0
-  resolution: "@esbuild/linux-arm64@npm:0.18.0"
+"@esbuild/linux-arm64@npm:0.18.1":
+  version: 0.18.1
+  resolution: "@esbuild/linux-arm64@npm:0.18.1"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
@@ -368,9 +368,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-arm@npm:0.18.0":
-  version: 0.18.0
-  resolution: "@esbuild/linux-arm@npm:0.18.0"
+"@esbuild/linux-arm@npm:0.18.1":
+  version: 0.18.1
+  resolution: "@esbuild/linux-arm@npm:0.18.1"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
@@ -382,17 +382,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-ia32@npm:0.18.0":
-  version: 0.18.0
-  resolution: "@esbuild/linux-ia32@npm:0.18.0"
+"@esbuild/linux-ia32@npm:0.18.1":
+  version: 0.18.1
+  resolution: "@esbuild/linux-ia32@npm:0.18.1"
   conditions: os=linux & cpu=ia32
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-loong64@npm:0.14.54":
-  version: 0.14.54
-  resolution: "@esbuild/linux-loong64@npm:0.14.54"
-  conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
 
@@ -403,9 +396,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-loong64@npm:0.18.0":
-  version: 0.18.0
-  resolution: "@esbuild/linux-loong64@npm:0.18.0"
+"@esbuild/linux-loong64@npm:0.18.1":
+  version: 0.18.1
+  resolution: "@esbuild/linux-loong64@npm:0.18.1"
   conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
@@ -417,9 +410,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-mips64el@npm:0.18.0":
-  version: 0.18.0
-  resolution: "@esbuild/linux-mips64el@npm:0.18.0"
+"@esbuild/linux-mips64el@npm:0.18.1":
+  version: 0.18.1
+  resolution: "@esbuild/linux-mips64el@npm:0.18.1"
   conditions: os=linux & cpu=mips64el
   languageName: node
   linkType: hard
@@ -431,9 +424,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-ppc64@npm:0.18.0":
-  version: 0.18.0
-  resolution: "@esbuild/linux-ppc64@npm:0.18.0"
+"@esbuild/linux-ppc64@npm:0.18.1":
+  version: 0.18.1
+  resolution: "@esbuild/linux-ppc64@npm:0.18.1"
   conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
@@ -445,9 +438,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-riscv64@npm:0.18.0":
-  version: 0.18.0
-  resolution: "@esbuild/linux-riscv64@npm:0.18.0"
+"@esbuild/linux-riscv64@npm:0.18.1":
+  version: 0.18.1
+  resolution: "@esbuild/linux-riscv64@npm:0.18.1"
   conditions: os=linux & cpu=riscv64
   languageName: node
   linkType: hard
@@ -459,9 +452,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-s390x@npm:0.18.0":
-  version: 0.18.0
-  resolution: "@esbuild/linux-s390x@npm:0.18.0"
+"@esbuild/linux-s390x@npm:0.18.1":
+  version: 0.18.1
+  resolution: "@esbuild/linux-s390x@npm:0.18.1"
   conditions: os=linux & cpu=s390x
   languageName: node
   linkType: hard
@@ -473,9 +466,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-x64@npm:0.18.0":
-  version: 0.18.0
-  resolution: "@esbuild/linux-x64@npm:0.18.0"
+"@esbuild/linux-x64@npm:0.18.1":
+  version: 0.18.1
+  resolution: "@esbuild/linux-x64@npm:0.18.1"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
@@ -487,9 +480,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/netbsd-x64@npm:0.18.0":
-  version: 0.18.0
-  resolution: "@esbuild/netbsd-x64@npm:0.18.0"
+"@esbuild/netbsd-x64@npm:0.18.1":
+  version: 0.18.1
+  resolution: "@esbuild/netbsd-x64@npm:0.18.1"
   conditions: os=netbsd & cpu=x64
   languageName: node
   linkType: hard
@@ -501,9 +494,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/openbsd-x64@npm:0.18.0":
-  version: 0.18.0
-  resolution: "@esbuild/openbsd-x64@npm:0.18.0"
+"@esbuild/openbsd-x64@npm:0.18.1":
+  version: 0.18.1
+  resolution: "@esbuild/openbsd-x64@npm:0.18.1"
   conditions: os=openbsd & cpu=x64
   languageName: node
   linkType: hard
@@ -515,9 +508,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/sunos-x64@npm:0.18.0":
-  version: 0.18.0
-  resolution: "@esbuild/sunos-x64@npm:0.18.0"
+"@esbuild/sunos-x64@npm:0.18.1":
+  version: 0.18.1
+  resolution: "@esbuild/sunos-x64@npm:0.18.1"
   conditions: os=sunos & cpu=x64
   languageName: node
   linkType: hard
@@ -529,9 +522,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/win32-arm64@npm:0.18.0":
-  version: 0.18.0
-  resolution: "@esbuild/win32-arm64@npm:0.18.0"
+"@esbuild/win32-arm64@npm:0.18.1":
+  version: 0.18.1
+  resolution: "@esbuild/win32-arm64@npm:0.18.1"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -543,9 +536,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/win32-ia32@npm:0.18.0":
-  version: 0.18.0
-  resolution: "@esbuild/win32-ia32@npm:0.18.0"
+"@esbuild/win32-ia32@npm:0.18.1":
+  version: 0.18.1
+  resolution: "@esbuild/win32-ia32@npm:0.18.1"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
@@ -557,9 +550,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/win32-x64@npm:0.18.0":
-  version: 0.18.0
-  resolution: "@esbuild/win32-x64@npm:0.18.0"
+"@esbuild/win32-x64@npm:0.18.1":
+  version: 0.18.1
+  resolution: "@esbuild/win32-x64@npm:0.18.1"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -596,13 +589,6 @@ __metadata:
     minimatch: ^3.1.2
     strip-json-comments: ^3.1.1
   checksum: ddc51f25f8524d8231db9c9bf03177e503d941a332e8d5ce3b10b09241be4d5584a378a529a27a527586bfbccf3031ae539eb891352033c340b012b4d0c81d92
-  languageName: node
-  linkType: hard
-
-"@eslint/js@npm:8.41.0":
-  version: 8.41.0
-  resolution: "@eslint/js@npm:8.41.0"
-  checksum: af013d70fe8d0429cdf5cd8b5dcc6fc384ed026c1eccb0cfe30f5849b968ab91645111373fd1b83282b38955b1bdfbe667c1a7dbda3b06cae753521223cad775
   languageName: node
   linkType: hard
 
@@ -679,17 +665,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@humanwhocodes/config-array@npm:^0.11.8":
-  version: 0.11.8
-  resolution: "@humanwhocodes/config-array@npm:0.11.8"
-  dependencies:
-    "@humanwhocodes/object-schema": ^1.2.1
-    debug: ^4.1.1
-    minimatch: ^3.0.5
-  checksum: 0fd6b3c54f1674ce0a224df09b9c2f9846d20b9e54fabae1281ecfc04f2e6ad69bf19e1d6af6a28f88e8aa3990168b6cb9e1ef755868c3256a630605ec2cb1d3
-  languageName: node
-  linkType: hard
-
 "@humanwhocodes/module-importer@npm:^1.0.1":
   version: 1.0.1
   resolution: "@humanwhocodes/module-importer@npm:1.0.1"
@@ -728,10 +703,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jspm/core@npm:2.0.0-beta.24":
-  version: 2.0.0-beta.24
-  resolution: "@jspm/core@npm:2.0.0-beta.24"
-  checksum: c3a986d523a61522794c26b809d1fb40b1404a45a5661ba476b5d529e9c15c4c0dc51983c95168532bcc7455a387f0eceeed06f4b386aa219173535fa53a0a62
+"@jspm/core@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@jspm/core@npm:2.0.1"
+  checksum: 611f37cadd8a76662309e89afb68bf5936d0fed16aacc8886fef0f0af94a9f7e1241ce6c619b650fa1064631374f6fcadad99be04c9cf504a47f5361746b8d7f
   languageName: node
   linkType: hard
 
@@ -819,16 +794,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/pluginutils@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "@rollup/pluginutils@npm:3.1.0"
+"@rollup/pluginutils@npm:^5.0.2":
+  version: 5.0.2
+  resolution: "@rollup/pluginutils@npm:5.0.2"
   dependencies:
-    "@types/estree": 0.0.39
-    estree-walker: ^1.0.1
-    picomatch: ^2.2.2
+    "@types/estree": ^1.0.0
+    estree-walker: ^2.0.2
+    picomatch: ^2.3.1
   peerDependencies:
-    rollup: ^1.20.0||^2.0.0
-  checksum: 8be16e27863c219edbb25a4e6ec2fe0e1e451d9e917b6a43cf2ae5bc025a6b8faaa40f82a6e53b66d0de37b58ff472c6c3d57a83037ae635041f8df959d6d9aa
+    rollup: ^1.20.0||^2.0.0||^3.0.0
+  peerDependenciesMeta:
+    rollup:
+      optional: true
+  checksum: edea15e543bebc7dcac3b0ac8bc7b8e8e6dbd46e2864dbe5dd28072de1fbd5b0e10d545a610c0edaa178e8a7ac432e2a2a52e547ece1308471412caba47db8ce
   languageName: node
   linkType: hard
 
@@ -855,17 +833,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sapphire/utilities@npm:3.12.0":
+"@sapphire/utilities@npm:3.12.0, @sapphire/utilities@npm:^3.11.0":
   version: 3.12.0
   resolution: "@sapphire/utilities@npm:3.12.0"
   checksum: 002f15263f157fdbb0603c233a43a5660cd3b45a4f3fddaa9d7066d187eec23f473ee42c8d071b0e3dec4e22b08bed337fb7eb336a02b59743a78ebc8922004e
-  languageName: node
-  linkType: hard
-
-"@sapphire/utilities@npm:^3.11.0":
-  version: 3.11.2
-  resolution: "@sapphire/utilities@npm:3.11.2"
-  checksum: af06b3f52156af397a3be564f992bedefd728ea2d44fee8ffdc00242de0454075e722091cc213d4ad2fb4ef5c3b78740bf5e7f75242851d31a56206f51a8f403
   languageName: node
   linkType: hard
 
@@ -920,10 +891,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:0.0.39":
-  version: 0.0.39
-  resolution: "@types/estree@npm:0.0.39"
-  checksum: 412fb5b9868f2c418126451821833414189b75cc6bf84361156feed733e3d92ec220b9d74a89e52722e03d5e241b2932732711b7497374a404fad49087adc248
+"@types/estree@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "@types/estree@npm:1.0.1"
+  checksum: e9aa175eacb797216fafce4d41e8202c7a75555bc55232dee0f9903d7171f8f19f0ae7d5191bb1a88cb90e65468be508c0df850a9fb81b4433b293a5a749899d
   languageName: node
   linkType: hard
 
@@ -2468,118 +2439,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-android-64@npm:0.14.54":
-  version: 0.14.54
-  resolution: "esbuild-android-64@npm:0.14.54"
-  conditions: os=android & cpu=x64
-  languageName: node
-  linkType: hard
-
-"esbuild-android-arm64@npm:0.14.54":
-  version: 0.14.54
-  resolution: "esbuild-android-arm64@npm:0.14.54"
-  conditions: os=android & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"esbuild-darwin-64@npm:0.14.54":
-  version: 0.14.54
-  resolution: "esbuild-darwin-64@npm:0.14.54"
-  conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
-"esbuild-darwin-arm64@npm:0.14.54":
-  version: 0.14.54
-  resolution: "esbuild-darwin-arm64@npm:0.14.54"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"esbuild-freebsd-64@npm:0.14.54":
-  version: 0.14.54
-  resolution: "esbuild-freebsd-64@npm:0.14.54"
-  conditions: os=freebsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"esbuild-freebsd-arm64@npm:0.14.54":
-  version: 0.14.54
-  resolution: "esbuild-freebsd-arm64@npm:0.14.54"
-  conditions: os=freebsd & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-32@npm:0.14.54":
-  version: 0.14.54
-  resolution: "esbuild-linux-32@npm:0.14.54"
-  conditions: os=linux & cpu=ia32
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-64@npm:0.14.54":
-  version: 0.14.54
-  resolution: "esbuild-linux-64@npm:0.14.54"
-  conditions: os=linux & cpu=x64
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-arm64@npm:0.14.54":
-  version: 0.14.54
-  resolution: "esbuild-linux-arm64@npm:0.14.54"
-  conditions: os=linux & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-arm@npm:0.14.54":
-  version: 0.14.54
-  resolution: "esbuild-linux-arm@npm:0.14.54"
-  conditions: os=linux & cpu=arm
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-mips64le@npm:0.14.54":
-  version: 0.14.54
-  resolution: "esbuild-linux-mips64le@npm:0.14.54"
-  conditions: os=linux & cpu=mips64el
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-ppc64le@npm:0.14.54":
-  version: 0.14.54
-  resolution: "esbuild-linux-ppc64le@npm:0.14.54"
-  conditions: os=linux & cpu=ppc64
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-riscv64@npm:0.14.54":
-  version: 0.14.54
-  resolution: "esbuild-linux-riscv64@npm:0.14.54"
-  conditions: os=linux & cpu=riscv64
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-s390x@npm:0.14.54":
-  version: 0.14.54
-  resolution: "esbuild-linux-s390x@npm:0.14.54"
-  conditions: os=linux & cpu=s390x
-  languageName: node
-  linkType: hard
-
-"esbuild-netbsd-64@npm:0.14.54":
-  version: 0.14.54
-  resolution: "esbuild-netbsd-64@npm:0.14.54"
-  conditions: os=netbsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"esbuild-openbsd-64@npm:0.14.54":
-  version: 0.14.54
-  resolution: "esbuild-openbsd-64@npm:0.14.54"
-  conditions: os=openbsd & cpu=x64
-  languageName: node
-  linkType: hard
-
 "esbuild-plugins-node-modules-polyfill@workspace:.":
   version: 0.0.0-use.local
   resolution: "esbuild-plugins-node-modules-polyfill@workspace:."
@@ -2589,121 +2448,21 @@ __metadata:
     "@favware/cliff-jumper": ^2.1.0
     "@favware/npm-deprecate": ^1.0.7
     cz-conventional-changelog: ^3.3.0
-    esbuild: ^0.18.0
+    esbuild: ^0.18.1
     eslint: ^8.42.0
     eslint-config-mahir: ^0.0.26
     husky: ^8.0.3
     lint-staged: ^13.2.2
-    modern-node-polyfills: ^0.1.3
+    modern-node-polyfills: ^1.0.0
     pinst: ^3.0.0
     prettier: ^2.8.8
     tsup: ^6.7.0
     typescript: ^5.1.3
     vitest: ^0.32.0
+  peerDependencies:
+    esbuild: ^0.14.0 || ^0.15.0 || ^0.16.0 || ^0.17.0 || ^0.18.0
   languageName: unknown
   linkType: soft
-
-"esbuild-sunos-64@npm:0.14.54":
-  version: 0.14.54
-  resolution: "esbuild-sunos-64@npm:0.14.54"
-  conditions: os=sunos & cpu=x64
-  languageName: node
-  linkType: hard
-
-"esbuild-windows-32@npm:0.14.54":
-  version: 0.14.54
-  resolution: "esbuild-windows-32@npm:0.14.54"
-  conditions: os=win32 & cpu=ia32
-  languageName: node
-  linkType: hard
-
-"esbuild-windows-64@npm:0.14.54":
-  version: 0.14.54
-  resolution: "esbuild-windows-64@npm:0.14.54"
-  conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
-"esbuild-windows-arm64@npm:0.14.54":
-  version: 0.14.54
-  resolution: "esbuild-windows-arm64@npm:0.14.54"
-  conditions: os=win32 & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"esbuild@npm:^0.14.54":
-  version: 0.14.54
-  resolution: "esbuild@npm:0.14.54"
-  dependencies:
-    "@esbuild/linux-loong64": 0.14.54
-    esbuild-android-64: 0.14.54
-    esbuild-android-arm64: 0.14.54
-    esbuild-darwin-64: 0.14.54
-    esbuild-darwin-arm64: 0.14.54
-    esbuild-freebsd-64: 0.14.54
-    esbuild-freebsd-arm64: 0.14.54
-    esbuild-linux-32: 0.14.54
-    esbuild-linux-64: 0.14.54
-    esbuild-linux-arm: 0.14.54
-    esbuild-linux-arm64: 0.14.54
-    esbuild-linux-mips64le: 0.14.54
-    esbuild-linux-ppc64le: 0.14.54
-    esbuild-linux-riscv64: 0.14.54
-    esbuild-linux-s390x: 0.14.54
-    esbuild-netbsd-64: 0.14.54
-    esbuild-openbsd-64: 0.14.54
-    esbuild-sunos-64: 0.14.54
-    esbuild-windows-32: 0.14.54
-    esbuild-windows-64: 0.14.54
-    esbuild-windows-arm64: 0.14.54
-  dependenciesMeta:
-    "@esbuild/linux-loong64":
-      optional: true
-    esbuild-android-64:
-      optional: true
-    esbuild-android-arm64:
-      optional: true
-    esbuild-darwin-64:
-      optional: true
-    esbuild-darwin-arm64:
-      optional: true
-    esbuild-freebsd-64:
-      optional: true
-    esbuild-freebsd-arm64:
-      optional: true
-    esbuild-linux-32:
-      optional: true
-    esbuild-linux-64:
-      optional: true
-    esbuild-linux-arm:
-      optional: true
-    esbuild-linux-arm64:
-      optional: true
-    esbuild-linux-mips64le:
-      optional: true
-    esbuild-linux-ppc64le:
-      optional: true
-    esbuild-linux-riscv64:
-      optional: true
-    esbuild-linux-s390x:
-      optional: true
-    esbuild-netbsd-64:
-      optional: true
-    esbuild-openbsd-64:
-      optional: true
-    esbuild-sunos-64:
-      optional: true
-    esbuild-windows-32:
-      optional: true
-    esbuild-windows-64:
-      optional: true
-    esbuild-windows-arm64:
-      optional: true
-  bin:
-    esbuild: bin/esbuild
-  checksum: 49e360b1185c797f5ca3a7f5f0a75121494d97ddf691f65ed1796e6257d318f928342a97f559bb8eced6a90cf604dd22db4a30e0dbbf15edd9dbf22459b639af
-  languageName: node
-  linkType: hard
 
 "esbuild@npm:^0.17.5, esbuild@npm:^0.17.6":
   version: 0.17.19
@@ -2782,32 +2541,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:^0.18.0":
-  version: 0.18.0
-  resolution: "esbuild@npm:0.18.0"
+"esbuild@npm:^0.18.1":
+  version: 0.18.1
+  resolution: "esbuild@npm:0.18.1"
   dependencies:
-    "@esbuild/android-arm": 0.18.0
-    "@esbuild/android-arm64": 0.18.0
-    "@esbuild/android-x64": 0.18.0
-    "@esbuild/darwin-arm64": 0.18.0
-    "@esbuild/darwin-x64": 0.18.0
-    "@esbuild/freebsd-arm64": 0.18.0
-    "@esbuild/freebsd-x64": 0.18.0
-    "@esbuild/linux-arm": 0.18.0
-    "@esbuild/linux-arm64": 0.18.0
-    "@esbuild/linux-ia32": 0.18.0
-    "@esbuild/linux-loong64": 0.18.0
-    "@esbuild/linux-mips64el": 0.18.0
-    "@esbuild/linux-ppc64": 0.18.0
-    "@esbuild/linux-riscv64": 0.18.0
-    "@esbuild/linux-s390x": 0.18.0
-    "@esbuild/linux-x64": 0.18.0
-    "@esbuild/netbsd-x64": 0.18.0
-    "@esbuild/openbsd-x64": 0.18.0
-    "@esbuild/sunos-x64": 0.18.0
-    "@esbuild/win32-arm64": 0.18.0
-    "@esbuild/win32-ia32": 0.18.0
-    "@esbuild/win32-x64": 0.18.0
+    "@esbuild/android-arm": 0.18.1
+    "@esbuild/android-arm64": 0.18.1
+    "@esbuild/android-x64": 0.18.1
+    "@esbuild/darwin-arm64": 0.18.1
+    "@esbuild/darwin-x64": 0.18.1
+    "@esbuild/freebsd-arm64": 0.18.1
+    "@esbuild/freebsd-x64": 0.18.1
+    "@esbuild/linux-arm": 0.18.1
+    "@esbuild/linux-arm64": 0.18.1
+    "@esbuild/linux-ia32": 0.18.1
+    "@esbuild/linux-loong64": 0.18.1
+    "@esbuild/linux-mips64el": 0.18.1
+    "@esbuild/linux-ppc64": 0.18.1
+    "@esbuild/linux-riscv64": 0.18.1
+    "@esbuild/linux-s390x": 0.18.1
+    "@esbuild/linux-x64": 0.18.1
+    "@esbuild/netbsd-x64": 0.18.1
+    "@esbuild/openbsd-x64": 0.18.1
+    "@esbuild/sunos-x64": 0.18.1
+    "@esbuild/win32-arm64": 0.18.1
+    "@esbuild/win32-ia32": 0.18.1
+    "@esbuild/win32-x64": 0.18.1
   dependenciesMeta:
     "@esbuild/android-arm":
       optional: true
@@ -2855,7 +2614,7 @@ __metadata:
       optional: true
   bin:
     esbuild: bin/esbuild
-  checksum: 47ec41ab20f10c6f73b27c518a4a7e46482cee12d0aa1019952f74c3813399128698d3e8114a950ba69317086dd47b0670472599abbe63402dbebe2eb294d99d
+  checksum: e7431e93fd395483c76f20e7944c258999550f3efc69ae9b9e37f2e317fd5b3aac53da350d82e5c79ef53a677a8baacffe0c079e88efa3c01184f3b58c2682d7
   languageName: node
   linkType: hard
 
@@ -3176,56 +2935,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^8.40.0":
-  version: 8.41.0
-  resolution: "eslint@npm:8.41.0"
-  dependencies:
-    "@eslint-community/eslint-utils": ^4.2.0
-    "@eslint-community/regexpp": ^4.4.0
-    "@eslint/eslintrc": ^2.0.3
-    "@eslint/js": 8.41.0
-    "@humanwhocodes/config-array": ^0.11.8
-    "@humanwhocodes/module-importer": ^1.0.1
-    "@nodelib/fs.walk": ^1.2.8
-    ajv: ^6.10.0
-    chalk: ^4.0.0
-    cross-spawn: ^7.0.2
-    debug: ^4.3.2
-    doctrine: ^3.0.0
-    escape-string-regexp: ^4.0.0
-    eslint-scope: ^7.2.0
-    eslint-visitor-keys: ^3.4.1
-    espree: ^9.5.2
-    esquery: ^1.4.2
-    esutils: ^2.0.2
-    fast-deep-equal: ^3.1.3
-    file-entry-cache: ^6.0.1
-    find-up: ^5.0.0
-    glob-parent: ^6.0.2
-    globals: ^13.19.0
-    graphemer: ^1.4.0
-    ignore: ^5.2.0
-    import-fresh: ^3.0.0
-    imurmurhash: ^0.1.4
-    is-glob: ^4.0.0
-    is-path-inside: ^3.0.3
-    js-yaml: ^4.1.0
-    json-stable-stringify-without-jsonify: ^1.0.1
-    levn: ^0.4.1
-    lodash.merge: ^4.6.2
-    minimatch: ^3.1.2
-    natural-compare: ^1.4.0
-    optionator: ^0.9.1
-    strip-ansi: ^6.0.1
-    strip-json-comments: ^3.1.0
-    text-table: ^0.2.0
-  bin:
-    eslint: bin/eslint.js
-  checksum: 09979a6f8451dcc508a7005b6670845c8a518376280b3fd96657a406b8b6ef29d0e480d1ba11b4eb48da93d607e0c55c9b877676fe089d09973ec152354e23b2
-  languageName: node
-  linkType: hard
-
-"eslint@npm:^8.42.0":
+"eslint@npm:^8.40.0, eslint@npm:^8.42.0":
   version: 8.42.0
   resolution: "eslint@npm:8.42.0"
   dependencies:
@@ -3317,10 +3027,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"estree-walker@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "estree-walker@npm:1.0.1"
-  checksum: 7e70da539691f6db03a08e7ce94f394ce2eef4180e136d251af299d41f92fb2d28ebcd9a6e393e3728d7970aeb5358705ddf7209d52fbcb2dd4693f95dcf925f
+"estree-walker@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "estree-walker@npm:2.0.2"
+  checksum: 6151e6f9828abe2259e57f5fd3761335bb0d2ebd76dc1a01048ccee22fabcfef3c0859300f6d83ff0d1927849368775ec5a6d265dde2f6de5a1be1721cd94efc
   languageName: node
   linkType: hard
 
@@ -5212,15 +4922,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"modern-node-polyfills@npm:^0.1.3":
-  version: 0.1.3
-  resolution: "modern-node-polyfills@npm:0.1.3"
+"modern-node-polyfills@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "modern-node-polyfills@npm:1.0.0"
   dependencies:
-    "@jspm/core": 2.0.0-beta.24
-    "@rollup/pluginutils": ^3.1.0
-    esbuild: ^0.14.54
+    "@jspm/core": ^2.0.1
+    "@rollup/pluginutils": ^5.0.2
     local-pkg: ^0.4.3
-  checksum: 16ce23fb4beae5a436ecf6d19aac03ce14d214004b5a9789293af51002cb5dea9d548a4e7c9116955eb402deae0ba83a5455fc461ebbc9fb2361f07e312a22c9
+  peerDependencies:
+    esbuild: ^0.14.0 || ^0.15.0 || ^0.16.0 || ^0.17.0 || ^0.18.0
+  checksum: 2cf0c7fe4c15efa02702576e799ce20e0ff85e4db39516cc566c2c17cd45702ec56f1f1b57e40d4126f4c94f2bcff6923ed48191d2323c0f059d51c2e2b45d7b
   languageName: node
   linkType: hard
 
@@ -5730,7 +5441,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^2.0.4, picomatch@npm:^2.2.1, picomatch@npm:^2.2.2, picomatch@npm:^2.3.1":
+"picomatch@npm:^2.0.4, picomatch@npm:^2.2.1, picomatch@npm:^2.3.1":
   version: 2.3.1
   resolution: "picomatch@npm:2.3.1"
   checksum: 050c865ce81119c4822c45d3c84f1ced46f93a0126febae20737bd05ca20589c564d6e9226977df859ed5e03dc73f02584a2b0faad36e896936238238b0446cf
@@ -7021,17 +6732,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.6.4 || ^5.0.0, typescript@npm:^5.0.4":
-  version: 5.0.4
-  resolution: "typescript@npm:5.0.4"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 82b94da3f4604a8946da585f7d6c3025fff8410779e5bde2855ab130d05e4fd08938b9e593b6ebed165bda6ad9292b230984f10952cf82f0a0ca07bbeaa08172
-  languageName: node
-  linkType: hard
-
-"typescript@npm:^5.1.3":
+"typescript@npm:^4.6.4 || ^5.0.0, typescript@npm:^5.0.4, typescript@npm:^5.1.3":
   version: 5.1.3
   resolution: "typescript@npm:5.1.3"
   bin:
@@ -7041,17 +6742,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.6.4 || ^5.0.0#~builtin<compat/typescript>, typescript@patch:typescript@^5.0.4#~builtin<compat/typescript>":
-  version: 5.0.4
-  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=b5f058"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: d26b6ba97b6d163c55dbdffd9bbb4c211667ebebc743accfeb2c8c0154aace7afd097b51165a72a5bad2cf65a4612259344ff60f8e642362aa1695c760d303ac
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@^5.1.3#~builtin<compat/typescript>":
+"typescript@patch:typescript@^4.6.4 || ^5.0.0#~builtin<compat/typescript>, typescript@patch:typescript@^5.0.4#~builtin<compat/typescript>, typescript@patch:typescript@^5.1.3#~builtin<compat/typescript>":
   version: 5.1.3
   resolution: "typescript@patch:typescript@npm%3A5.1.3#~builtin<compat/typescript>::version=5.1.3&hash=5da071"
   bin:


### PR DESCRIPTION
Updated version of `modern-node-polyfills` includes https://github.com/Aslemammad/modern-node-polyfills/pull/14, which prevents problems like https://github.com/remix-run/remix/issues/6288#issuecomment-1585287474