### PR TITLE
fix: cache usage of modern-node-polyfills API

### DIFF
--- a/src/lib/utils/util.ts
+++ b/src/lib/utils/util.ts
@@ -1,6 +1,6 @@
+/* eslint-disable unicorn/prefer-string-replace-all -- node v14 doesn't supports string.replaceAll*/
 import { polyfillContent, polyfillPath } from 'modern-node-polyfills';
 
-/* eslint-disable unicorn/prefer-string-replace-all -- node v14 doesn't supports string.replaceAll*/
 export const escapeRegex = (str: string) => {
 	return str.replace(/[$()*+.?[\\\]^{|}]/g, '\\$&').replace(/-/g, '\\x2d');
 };

--- a/src/lib/utils/util.ts
+++ b/src/lib/utils/util.ts
@@ -39,7 +39,7 @@ export const getCachedPolyfillPath = (_importPath: string): Promise<string> => {
 
 const polyfillContentAndTransform = async (importPath: string) => {
 	const content = await polyfillContent(importPath);
-	return content.replaceAll('eval(', '(0,eval)(');
+	return content.replace(/eval\(/g, '(0,eval)(');
 };
 
 const polyfillContentCache: Map<string, Promise<string>> = new Map();

--- a/src/lib/utils/util.ts
+++ b/src/lib/utils/util.ts
@@ -24,7 +24,7 @@ const normalizeNodeBuiltinPath = (path: string) => {
 };
 
 const polyfillPathCache: Map<string, Promise<string>> = new Map();
-export const getCachedPolyfillPath = async (_importPath: string): Promise<string> => {
+export const getCachedPolyfillPath = (_importPath: string): Promise<string> => {
 	const normalizedImportPath = normalizeNodeBuiltinPath(_importPath);
 
 	const cachedPromise = polyfillPathCache.get(normalizedImportPath);
@@ -43,7 +43,7 @@ const polyfillContentAndTransform = async (importPath: string) => {
 };
 
 const polyfillContentCache: Map<string, Promise<string>> = new Map();
-export const getCachedPolyfillContent = async (_importPath: string): Promise<string> => {
+export const getCachedPolyfillContent = (_importPath: string): Promise<string> => {
 	const normalizedImportPath = normalizeNodeBuiltinPath(_importPath);
 
 	const cachedPromise = polyfillContentCache.get(normalizedImportPath);


### PR DESCRIPTION
First of all, thanks for all your hard work on this plugin :)

This plugin was recently added to Remix, replacing an older polyfills plugin, but we've found that the calls to `polyfillPath` and `polyfillContent` can be quite slow, even on rebuilds. To dramatically improve build performance, this PR introduces a cache for these functions.

Note that the cache stores _promises_ rather than final values because there might be multiple instances of the plugin running at the same time, which is the case in Remix, and we want any subsequent calls to wait on the same operation.

**Status and versioning classification:** 
- Code changes have been tested and working fine, or there are no code changes
