### PR TITLE
fix: handle frozen default exports

### DIFF
--- a/src/lib/utils/util.ts
+++ b/src/lib/utils/util.ts
@@ -6,17 +6,7 @@ export const escapeRegex = (str: string) => {
 };
 
 export const commonJsTemplate = ({ importPath }: { importPath: string }) => {
-	return `
-const polyfill = require('${importPath}')
-if (polyfill && polyfill.default) {
-    module.exports = polyfill.default
-    for (let k in polyfill) {
-        module.exports[k] = polyfill[k]
-    }
-} else if (polyfill)  {
-    module.exports = polyfill
-}
-`;
+	return `export * from '${importPath}'`;
 };
 
 const normalizeNodeBuiltinPath = (path: string) => {


### PR DESCRIPTION
We had a bug report against Remix: https://github.com/remix-run/remix/issues/6665

When polyfilling `tty`, I get the following error:

```
TypeError: Cannot assign to read only property 'ReadStream' of object '[object Object]'

        module.exports[k5] = polyfill[k5];
                       ^
```

After some digging, I discovered that this is because the JSPM polyfill for `tty` looks like this:

```js
// ...
var m = /*#__PURE__*/Object.freeze({
  __proto__: null,
  isatty: isatty,
  ReadStream: ReadStream,
  WriteStream: WriteStream
});

export { ReadStream, WriteStream, m as default, isatty };
```

The default export is a read-only object since it's been passed to `Object.freeze`, and then the code injected by this plugin attempts to mutate it:

```js
module.exports = polyfill.default
for (let k in polyfill) {
  module.exports[k] = polyfill[k]
}
```

I initially tried to fix the injected CommonJS code by using `Object.assign({}, polyfill.default, polyfill)`, but unless I'm missing something, I found that esbuild is able to handle `export *` even when imported from a CommonJS file. Using ES modules to handle the re-export seems a lot cleaner since it avoids these sorts of issues entirely, otherwise we'd need to handle all sorts of edge cases when re-exporting.

**Status and versioning classification:**

- Code changes have been tested and working fine, or there are no code changes
