### PR TITLE
feat: support `process` and `Buffer` globals

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## Description
 
-Polyfills nodejs builtin modules for the browser.
+Polyfills nodejs builtin modules and globals for the browser.
 
 ## Features
 
@@ -19,6 +19,7 @@ Polyfills nodejs builtin modules for the browser.
 -   Offers CJS and ESM builds
 -   Full TypeScript & JavaScript support
 -   Supports `node:` protocol
+-   Optionally injects globals
 
 ## Install
 
@@ -34,6 +35,21 @@ import { nodeModulesPolyfillPlugin } from 'esbuild-plugins-node-modules-polyfill
 import { build } from 'esbuild';
 build({
 	plugins: [nodeModulesPolyfillPlugin()],
+});
+```
+
+Optionally inject globals when detected:
+
+```ts
+import { nodeModulesPolyfillPlugin } from 'esbuild-plugins-node-modules-polyfill';
+import { build } from 'esbuild';
+build({
+	plugins: [nodeModulesPolyfillPlugin({
+		globals: {
+			process: true,
+			Buffer: true,
+		}
+	})],
 });
 ```
 

--- a/globals/Buffer.js
+++ b/globals/Buffer.js
@@ -1,0 +1,1 @@
+export { Buffer } from 'node:buffer';

--- a/globals/process.js
+++ b/globals/process.js
@@ -1,0 +1,1 @@
+export { default as process } from 'node:process';

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "esbuild-plugins-node-modules-polyfill",
 	"version": "1.0.16",
-	"description": "Polyfills nodejs builtin modules for the browser.",
+	"description": "Polyfills nodejs builtin modules and globals for the browser.",
 	"main": "dist/index.js",
 	"module": "dist/index.mjs",
 	"types": "dist/index.d.ts",
@@ -60,7 +60,8 @@
 	"files": [
 		"dist/**/*.js*",
 		"dist/**/*.mjs*",
-		"dist/**/*.d*"
+		"dist/**/*.d*",
+		"inject/**/*.js"
 	],
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 		"dist/**/*.js*",
 		"dist/**/*.mjs*",
 		"dist/**/*.d*",
-		"inject/**/*.js"
+		"globals/**/*.js"
 	],
 	"repository": {
 		"type": "git",

--- a/src/lib/plugin.ts
+++ b/src/lib/plugin.ts
@@ -9,6 +9,10 @@ import type esbuild from 'esbuild';
 const NAME = 'node-modules-polyfills';
 
 export interface NodePolyfillsOptions {
+	globals?: {
+		Buffer?: boolean;
+		process?: boolean;
+	};
 	name?: string;
 	namespace?: string;
 }
@@ -47,7 +51,7 @@ const loader = async (args: esbuild.OnLoadArgs): Promise<esbuild.OnLoadResult> =
 };
 
 export const nodeModulesPolyfillPlugin = (options: NodePolyfillsOptions = {}): Plugin => {
-	const { namespace = NAME, name = NAME } = options;
+	const { globals = {}, namespace = NAME, name = NAME } = options;
 	if (namespace.endsWith('commonjs')) {
 		throw new Error(`namespace ${namespace} must not end with commonjs`);
 	}
@@ -62,6 +66,16 @@ export const nodeModulesPolyfillPlugin = (options: NodePolyfillsOptions = {}): P
 				initialOptions.define.global = 'globalThis';
 			} else if (!initialOptions.define) {
 				initialOptions.define = { global: 'globalThis' };
+			}
+
+			initialOptions.inject = initialOptions.inject ?? [];
+
+			if (globals.Buffer) {
+				initialOptions.inject.push(path.resolve(__dirname, '../globals/Buffer.js'));
+			}
+
+			if (globals.process) {
+				initialOptions.inject.push(path.resolve(__dirname, '../globals/process.js'));
 			}
 
 			onLoad({ filter: /.*/, namespace }, loader);

--- a/tests/fixtures/input/globalBuffer.ts
+++ b/tests/fixtures/input/globalBuffer.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-restricted-globals, n/prefer-global/buffer
+console.log(Buffer.from('Hello world'));

--- a/tests/fixtures/input/globalProcess.ts
+++ b/tests/fixtures/input/globalProcess.ts
@@ -1,0 +1,6 @@
+// eslint-disable-next-line no-restricted-globals, n/prefer-global/process
+console.log(process.version);
+
+// Ensure that environment variables can still be injected via `define`
+// eslint-disable-next-line no-restricted-globals, n/prefer-global/process
+console.log(process.env.NODE_ENV);

--- a/tests/scenarios/__snapshots__/globalBuffer.test.ts.snap
+++ b/tests/scenarios/__snapshots__/globalBuffer.test.ts.snap
@@ -1,0 +1,1857 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Global Buffer Test > GIVEN a file that references the "Buffer" global THEN polyfill it 1`] = `
+"\\"use strict\\";
+(() => {
+  // node-modules-polyfills:node:buffer
+  var exports$3 = {};
+  var _dewExec$2 = false;
+  function dew$2() {
+    if (_dewExec$2)
+      return exports$3;
+    _dewExec$2 = true;
+    exports$3.byteLength = byteLength;
+    exports$3.toByteArray = toByteArray;
+    exports$3.fromByteArray = fromByteArray;
+    var lookup = [];
+    var revLookup = [];
+    var Arr = typeof Uint8Array !== \\"undefined\\" ? Uint8Array : Array;
+    var code = \\"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/\\";
+    for (var i = 0, len = code.length; i < len; ++i) {
+      lookup[i] = code[i];
+      revLookup[code.charCodeAt(i)] = i;
+    }
+    revLookup[\\"-\\".charCodeAt(0)] = 62;
+    revLookup[\\"_\\".charCodeAt(0)] = 63;
+    function getLens(b64) {
+      var len2 = b64.length;
+      if (len2 % 4 > 0) {
+        throw new Error(\\"Invalid string. Length must be a multiple of 4\\");
+      }
+      var validLen = b64.indexOf(\\"=\\");
+      if (validLen === -1)
+        validLen = len2;
+      var placeHoldersLen = validLen === len2 ? 0 : 4 - validLen % 4;
+      return [validLen, placeHoldersLen];
+    }
+    function byteLength(b64) {
+      var lens = getLens(b64);
+      var validLen = lens[0];
+      var placeHoldersLen = lens[1];
+      return (validLen + placeHoldersLen) * 3 / 4 - placeHoldersLen;
+    }
+    function _byteLength(b64, validLen, placeHoldersLen) {
+      return (validLen + placeHoldersLen) * 3 / 4 - placeHoldersLen;
+    }
+    function toByteArray(b64) {
+      var tmp;
+      var lens = getLens(b64);
+      var validLen = lens[0];
+      var placeHoldersLen = lens[1];
+      var arr = new Arr(_byteLength(b64, validLen, placeHoldersLen));
+      var curByte = 0;
+      var len2 = placeHoldersLen > 0 ? validLen - 4 : validLen;
+      var i2;
+      for (i2 = 0; i2 < len2; i2 += 4) {
+        tmp = revLookup[b64.charCodeAt(i2)] << 18 | revLookup[b64.charCodeAt(i2 + 1)] << 12 | revLookup[b64.charCodeAt(i2 + 2)] << 6 | revLookup[b64.charCodeAt(i2 + 3)];
+        arr[curByte++] = tmp >> 16 & 255;
+        arr[curByte++] = tmp >> 8 & 255;
+        arr[curByte++] = tmp & 255;
+      }
+      if (placeHoldersLen === 2) {
+        tmp = revLookup[b64.charCodeAt(i2)] << 2 | revLookup[b64.charCodeAt(i2 + 1)] >> 4;
+        arr[curByte++] = tmp & 255;
+      }
+      if (placeHoldersLen === 1) {
+        tmp = revLookup[b64.charCodeAt(i2)] << 10 | revLookup[b64.charCodeAt(i2 + 1)] << 4 | revLookup[b64.charCodeAt(i2 + 2)] >> 2;
+        arr[curByte++] = tmp >> 8 & 255;
+        arr[curByte++] = tmp & 255;
+      }
+      return arr;
+    }
+    function tripletToBase64(num) {
+      return lookup[num >> 18 & 63] + lookup[num >> 12 & 63] + lookup[num >> 6 & 63] + lookup[num & 63];
+    }
+    function encodeChunk(uint8, start, end) {
+      var tmp;
+      var output = [];
+      for (var i2 = start; i2 < end; i2 += 3) {
+        tmp = (uint8[i2] << 16 & 16711680) + (uint8[i2 + 1] << 8 & 65280) + (uint8[i2 + 2] & 255);
+        output.push(tripletToBase64(tmp));
+      }
+      return output.join(\\"\\");
+    }
+    function fromByteArray(uint8) {
+      var tmp;
+      var len2 = uint8.length;
+      var extraBytes = len2 % 3;
+      var parts = [];
+      var maxChunkLength = 16383;
+      for (var i2 = 0, len22 = len2 - extraBytes; i2 < len22; i2 += maxChunkLength) {
+        parts.push(encodeChunk(uint8, i2, i2 + maxChunkLength > len22 ? len22 : i2 + maxChunkLength));
+      }
+      if (extraBytes === 1) {
+        tmp = uint8[len2 - 1];
+        parts.push(lookup[tmp >> 2] + lookup[tmp << 4 & 63] + \\"==\\");
+      } else if (extraBytes === 2) {
+        tmp = (uint8[len2 - 2] << 8) + uint8[len2 - 1];
+        parts.push(lookup[tmp >> 10] + lookup[tmp >> 4 & 63] + lookup[tmp << 2 & 63] + \\"=\\");
+      }
+      return parts.join(\\"\\");
+    }
+    return exports$3;
+  }
+  var exports$2 = {};
+  var _dewExec$1 = false;
+  function dew$1() {
+    if (_dewExec$1)
+      return exports$2;
+    _dewExec$1 = true;
+    exports$2.read = function(buffer, offset, isLE, mLen, nBytes) {
+      var e, m;
+      var eLen = nBytes * 8 - mLen - 1;
+      var eMax = (1 << eLen) - 1;
+      var eBias = eMax >> 1;
+      var nBits = -7;
+      var i = isLE ? nBytes - 1 : 0;
+      var d = isLE ? -1 : 1;
+      var s = buffer[offset + i];
+      i += d;
+      e = s & (1 << -nBits) - 1;
+      s >>= -nBits;
+      nBits += eLen;
+      for (; nBits > 0; e = e * 256 + buffer[offset + i], i += d, nBits -= 8) {
+      }
+      m = e & (1 << -nBits) - 1;
+      e >>= -nBits;
+      nBits += mLen;
+      for (; nBits > 0; m = m * 256 + buffer[offset + i], i += d, nBits -= 8) {
+      }
+      if (e === 0) {
+        e = 1 - eBias;
+      } else if (e === eMax) {
+        return m ? NaN : (s ? -1 : 1) * Infinity;
+      } else {
+        m = m + Math.pow(2, mLen);
+        e = e - eBias;
+      }
+      return (s ? -1 : 1) * m * Math.pow(2, e - mLen);
+    };
+    exports$2.write = function(buffer, value, offset, isLE, mLen, nBytes) {
+      var e, m, c;
+      var eLen = nBytes * 8 - mLen - 1;
+      var eMax = (1 << eLen) - 1;
+      var eBias = eMax >> 1;
+      var rt = mLen === 23 ? Math.pow(2, -24) - Math.pow(2, -77) : 0;
+      var i = isLE ? 0 : nBytes - 1;
+      var d = isLE ? 1 : -1;
+      var s = value < 0 || value === 0 && 1 / value < 0 ? 1 : 0;
+      value = Math.abs(value);
+      if (isNaN(value) || value === Infinity) {
+        m = isNaN(value) ? 1 : 0;
+        e = eMax;
+      } else {
+        e = Math.floor(Math.log(value) / Math.LN2);
+        if (value * (c = Math.pow(2, -e)) < 1) {
+          e--;
+          c *= 2;
+        }
+        if (e + eBias >= 1) {
+          value += rt / c;
+        } else {
+          value += rt * Math.pow(2, 1 - eBias);
+        }
+        if (value * c >= 2) {
+          e++;
+          c /= 2;
+        }
+        if (e + eBias >= eMax) {
+          m = 0;
+          e = eMax;
+        } else if (e + eBias >= 1) {
+          m = (value * c - 1) * Math.pow(2, mLen);
+          e = e + eBias;
+        } else {
+          m = value * Math.pow(2, eBias - 1) * Math.pow(2, mLen);
+          e = 0;
+        }
+      }
+      for (; mLen >= 8; buffer[offset + i] = m & 255, i += d, m /= 256, mLen -= 8) {
+      }
+      e = e << mLen | m;
+      eLen += mLen;
+      for (; eLen > 0; buffer[offset + i] = e & 255, i += d, e /= 256, eLen -= 8) {
+      }
+      buffer[offset + i - d] |= s * 128;
+    };
+    return exports$2;
+  }
+  var exports$1 = {};
+  var _dewExec = false;
+  function dew() {
+    if (_dewExec)
+      return exports$1;
+    _dewExec = true;
+    const base64 = dew$2();
+    const ieee754 = dew$1();
+    const customInspectSymbol = typeof Symbol === \\"function\\" && typeof Symbol[\\"for\\"] === \\"function\\" ? Symbol[\\"for\\"](\\"nodejs.util.inspect.custom\\") : null;
+    exports$1.Buffer = Buffer2;
+    exports$1.SlowBuffer = SlowBuffer;
+    exports$1.INSPECT_MAX_BYTES = 50;
+    const K_MAX_LENGTH = 2147483647;
+    exports$1.kMaxLength = K_MAX_LENGTH;
+    Buffer2.TYPED_ARRAY_SUPPORT = typedArraySupport();
+    if (!Buffer2.TYPED_ARRAY_SUPPORT && typeof console !== \\"undefined\\" && typeof console.error === \\"function\\") {
+      console.error(\\"This browser lacks typed array (Uint8Array) support which is required by \`buffer\` v5.x. Use \`buffer\` v4.x if you require old browser support.\\");
+    }
+    function typedArraySupport() {
+      try {
+        const arr = new Uint8Array(1);
+        const proto = {
+          foo: function() {
+            return 42;
+          }
+        };
+        Object.setPrototypeOf(proto, Uint8Array.prototype);
+        Object.setPrototypeOf(arr, proto);
+        return arr.foo() === 42;
+      } catch (e) {
+        return false;
+      }
+    }
+    Object.defineProperty(Buffer2.prototype, \\"parent\\", {
+      enumerable: true,
+      get: function() {
+        if (!Buffer2.isBuffer(this))
+          return void 0;
+        return this.buffer;
+      }
+    });
+    Object.defineProperty(Buffer2.prototype, \\"offset\\", {
+      enumerable: true,
+      get: function() {
+        if (!Buffer2.isBuffer(this))
+          return void 0;
+        return this.byteOffset;
+      }
+    });
+    function createBuffer(length) {
+      if (length > K_MAX_LENGTH) {
+        throw new RangeError('The value \\"' + length + '\\" is invalid for option \\"size\\"');
+      }
+      const buf = new Uint8Array(length);
+      Object.setPrototypeOf(buf, Buffer2.prototype);
+      return buf;
+    }
+    function Buffer2(arg, encodingOrOffset, length) {
+      if (typeof arg === \\"number\\") {
+        if (typeof encodingOrOffset === \\"string\\") {
+          throw new TypeError('The \\"string\\" argument must be of type string. Received type number');
+        }
+        return allocUnsafe(arg);
+      }
+      return from(arg, encodingOrOffset, length);
+    }
+    Buffer2.poolSize = 8192;
+    function from(value, encodingOrOffset, length) {
+      if (typeof value === \\"string\\") {
+        return fromString(value, encodingOrOffset);
+      }
+      if (ArrayBuffer.isView(value)) {
+        return fromArrayView(value);
+      }
+      if (value == null) {
+        throw new TypeError(\\"The first argument must be one of type string, Buffer, ArrayBuffer, Array, or Array-like Object. Received type \\" + typeof value);
+      }
+      if (isInstance(value, ArrayBuffer) || value && isInstance(value.buffer, ArrayBuffer)) {
+        return fromArrayBuffer(value, encodingOrOffset, length);
+      }
+      if (typeof SharedArrayBuffer !== \\"undefined\\" && (isInstance(value, SharedArrayBuffer) || value && isInstance(value.buffer, SharedArrayBuffer))) {
+        return fromArrayBuffer(value, encodingOrOffset, length);
+      }
+      if (typeof value === \\"number\\") {
+        throw new TypeError('The \\"value\\" argument must not be of type number. Received type number');
+      }
+      const valueOf = value.valueOf && value.valueOf();
+      if (valueOf != null && valueOf !== value) {
+        return Buffer2.from(valueOf, encodingOrOffset, length);
+      }
+      const b = fromObject(value);
+      if (b)
+        return b;
+      if (typeof Symbol !== \\"undefined\\" && Symbol.toPrimitive != null && typeof value[Symbol.toPrimitive] === \\"function\\") {
+        return Buffer2.from(value[Symbol.toPrimitive](\\"string\\"), encodingOrOffset, length);
+      }
+      throw new TypeError(\\"The first argument must be one of type string, Buffer, ArrayBuffer, Array, or Array-like Object. Received type \\" + typeof value);
+    }
+    Buffer2.from = function(value, encodingOrOffset, length) {
+      return from(value, encodingOrOffset, length);
+    };
+    Object.setPrototypeOf(Buffer2.prototype, Uint8Array.prototype);
+    Object.setPrototypeOf(Buffer2, Uint8Array);
+    function assertSize(size) {
+      if (typeof size !== \\"number\\") {
+        throw new TypeError('\\"size\\" argument must be of type number');
+      } else if (size < 0) {
+        throw new RangeError('The value \\"' + size + '\\" is invalid for option \\"size\\"');
+      }
+    }
+    function alloc(size, fill, encoding) {
+      assertSize(size);
+      if (size <= 0) {
+        return createBuffer(size);
+      }
+      if (fill !== void 0) {
+        return typeof encoding === \\"string\\" ? createBuffer(size).fill(fill, encoding) : createBuffer(size).fill(fill);
+      }
+      return createBuffer(size);
+    }
+    Buffer2.alloc = function(size, fill, encoding) {
+      return alloc(size, fill, encoding);
+    };
+    function allocUnsafe(size) {
+      assertSize(size);
+      return createBuffer(size < 0 ? 0 : checked(size) | 0);
+    }
+    Buffer2.allocUnsafe = function(size) {
+      return allocUnsafe(size);
+    };
+    Buffer2.allocUnsafeSlow = function(size) {
+      return allocUnsafe(size);
+    };
+    function fromString(string, encoding) {
+      if (typeof encoding !== \\"string\\" || encoding === \\"\\") {
+        encoding = \\"utf8\\";
+      }
+      if (!Buffer2.isEncoding(encoding)) {
+        throw new TypeError(\\"Unknown encoding: \\" + encoding);
+      }
+      const length = byteLength(string, encoding) | 0;
+      let buf = createBuffer(length);
+      const actual = buf.write(string, encoding);
+      if (actual !== length) {
+        buf = buf.slice(0, actual);
+      }
+      return buf;
+    }
+    function fromArrayLike(array) {
+      const length = array.length < 0 ? 0 : checked(array.length) | 0;
+      const buf = createBuffer(length);
+      for (let i = 0; i < length; i += 1) {
+        buf[i] = array[i] & 255;
+      }
+      return buf;
+    }
+    function fromArrayView(arrayView) {
+      if (isInstance(arrayView, Uint8Array)) {
+        const copy = new Uint8Array(arrayView);
+        return fromArrayBuffer(copy.buffer, copy.byteOffset, copy.byteLength);
+      }
+      return fromArrayLike(arrayView);
+    }
+    function fromArrayBuffer(array, byteOffset, length) {
+      if (byteOffset < 0 || array.byteLength < byteOffset) {
+        throw new RangeError('\\"offset\\" is outside of buffer bounds');
+      }
+      if (array.byteLength < byteOffset + (length || 0)) {
+        throw new RangeError('\\"length\\" is outside of buffer bounds');
+      }
+      let buf;
+      if (byteOffset === void 0 && length === void 0) {
+        buf = new Uint8Array(array);
+      } else if (length === void 0) {
+        buf = new Uint8Array(array, byteOffset);
+      } else {
+        buf = new Uint8Array(array, byteOffset, length);
+      }
+      Object.setPrototypeOf(buf, Buffer2.prototype);
+      return buf;
+    }
+    function fromObject(obj) {
+      if (Buffer2.isBuffer(obj)) {
+        const len = checked(obj.length) | 0;
+        const buf = createBuffer(len);
+        if (buf.length === 0) {
+          return buf;
+        }
+        obj.copy(buf, 0, 0, len);
+        return buf;
+      }
+      if (obj.length !== void 0) {
+        if (typeof obj.length !== \\"number\\" || numberIsNaN(obj.length)) {
+          return createBuffer(0);
+        }
+        return fromArrayLike(obj);
+      }
+      if (obj.type === \\"Buffer\\" && Array.isArray(obj.data)) {
+        return fromArrayLike(obj.data);
+      }
+    }
+    function checked(length) {
+      if (length >= K_MAX_LENGTH) {
+        throw new RangeError(\\"Attempt to allocate Buffer larger than maximum size: 0x\\" + K_MAX_LENGTH.toString(16) + \\" bytes\\");
+      }
+      return length | 0;
+    }
+    function SlowBuffer(length) {
+      if (+length != length) {
+        length = 0;
+      }
+      return Buffer2.alloc(+length);
+    }
+    Buffer2.isBuffer = function isBuffer(b) {
+      return b != null && b._isBuffer === true && b !== Buffer2.prototype;
+    };
+    Buffer2.compare = function compare(a, b) {
+      if (isInstance(a, Uint8Array))
+        a = Buffer2.from(a, a.offset, a.byteLength);
+      if (isInstance(b, Uint8Array))
+        b = Buffer2.from(b, b.offset, b.byteLength);
+      if (!Buffer2.isBuffer(a) || !Buffer2.isBuffer(b)) {
+        throw new TypeError('The \\"buf1\\", \\"buf2\\" arguments must be one of type Buffer or Uint8Array');
+      }
+      if (a === b)
+        return 0;
+      let x = a.length;
+      let y = b.length;
+      for (let i = 0, len = Math.min(x, y); i < len; ++i) {
+        if (a[i] !== b[i]) {
+          x = a[i];
+          y = b[i];
+          break;
+        }
+      }
+      if (x < y)
+        return -1;
+      if (y < x)
+        return 1;
+      return 0;
+    };
+    Buffer2.isEncoding = function isEncoding(encoding) {
+      switch (String(encoding).toLowerCase()) {
+        case \\"hex\\":
+        case \\"utf8\\":
+        case \\"utf-8\\":
+        case \\"ascii\\":
+        case \\"latin1\\":
+        case \\"binary\\":
+        case \\"base64\\":
+        case \\"ucs2\\":
+        case \\"ucs-2\\":
+        case \\"utf16le\\":
+        case \\"utf-16le\\":
+          return true;
+        default:
+          return false;
+      }
+    };
+    Buffer2.concat = function concat(list, length) {
+      if (!Array.isArray(list)) {
+        throw new TypeError('\\"list\\" argument must be an Array of Buffers');
+      }
+      if (list.length === 0) {
+        return Buffer2.alloc(0);
+      }
+      let i;
+      if (length === void 0) {
+        length = 0;
+        for (i = 0; i < list.length; ++i) {
+          length += list[i].length;
+        }
+      }
+      const buffer = Buffer2.allocUnsafe(length);
+      let pos = 0;
+      for (i = 0; i < list.length; ++i) {
+        let buf = list[i];
+        if (isInstance(buf, Uint8Array)) {
+          if (pos + buf.length > buffer.length) {
+            if (!Buffer2.isBuffer(buf))
+              buf = Buffer2.from(buf);
+            buf.copy(buffer, pos);
+          } else {
+            Uint8Array.prototype.set.call(buffer, buf, pos);
+          }
+        } else if (!Buffer2.isBuffer(buf)) {
+          throw new TypeError('\\"list\\" argument must be an Array of Buffers');
+        } else {
+          buf.copy(buffer, pos);
+        }
+        pos += buf.length;
+      }
+      return buffer;
+    };
+    function byteLength(string, encoding) {
+      if (Buffer2.isBuffer(string)) {
+        return string.length;
+      }
+      if (ArrayBuffer.isView(string) || isInstance(string, ArrayBuffer)) {
+        return string.byteLength;
+      }
+      if (typeof string !== \\"string\\") {
+        throw new TypeError('The \\"string\\" argument must be one of type string, Buffer, or ArrayBuffer. Received type ' + typeof string);
+      }
+      const len = string.length;
+      const mustMatch = arguments.length > 2 && arguments[2] === true;
+      if (!mustMatch && len === 0)
+        return 0;
+      let loweredCase = false;
+      for (; ; ) {
+        switch (encoding) {
+          case \\"ascii\\":
+          case \\"latin1\\":
+          case \\"binary\\":
+            return len;
+          case \\"utf8\\":
+          case \\"utf-8\\":
+            return utf8ToBytes(string).length;
+          case \\"ucs2\\":
+          case \\"ucs-2\\":
+          case \\"utf16le\\":
+          case \\"utf-16le\\":
+            return len * 2;
+          case \\"hex\\":
+            return len >>> 1;
+          case \\"base64\\":
+            return base64ToBytes(string).length;
+          default:
+            if (loweredCase) {
+              return mustMatch ? -1 : utf8ToBytes(string).length;
+            }
+            encoding = (\\"\\" + encoding).toLowerCase();
+            loweredCase = true;
+        }
+      }
+    }
+    Buffer2.byteLength = byteLength;
+    function slowToString(encoding, start, end) {
+      let loweredCase = false;
+      if (start === void 0 || start < 0) {
+        start = 0;
+      }
+      if (start > this.length) {
+        return \\"\\";
+      }
+      if (end === void 0 || end > this.length) {
+        end = this.length;
+      }
+      if (end <= 0) {
+        return \\"\\";
+      }
+      end >>>= 0;
+      start >>>= 0;
+      if (end <= start) {
+        return \\"\\";
+      }
+      if (!encoding)
+        encoding = \\"utf8\\";
+      while (true) {
+        switch (encoding) {
+          case \\"hex\\":
+            return hexSlice(this, start, end);
+          case \\"utf8\\":
+          case \\"utf-8\\":
+            return utf8Slice(this, start, end);
+          case \\"ascii\\":
+            return asciiSlice(this, start, end);
+          case \\"latin1\\":
+          case \\"binary\\":
+            return latin1Slice(this, start, end);
+          case \\"base64\\":
+            return base64Slice(this, start, end);
+          case \\"ucs2\\":
+          case \\"ucs-2\\":
+          case \\"utf16le\\":
+          case \\"utf-16le\\":
+            return utf16leSlice(this, start, end);
+          default:
+            if (loweredCase)
+              throw new TypeError(\\"Unknown encoding: \\" + encoding);
+            encoding = (encoding + \\"\\").toLowerCase();
+            loweredCase = true;
+        }
+      }
+    }
+    Buffer2.prototype._isBuffer = true;
+    function swap(b, n, m) {
+      const i = b[n];
+      b[n] = b[m];
+      b[m] = i;
+    }
+    Buffer2.prototype.swap16 = function swap16() {
+      const len = this.length;
+      if (len % 2 !== 0) {
+        throw new RangeError(\\"Buffer size must be a multiple of 16-bits\\");
+      }
+      for (let i = 0; i < len; i += 2) {
+        swap(this, i, i + 1);
+      }
+      return this;
+    };
+    Buffer2.prototype.swap32 = function swap32() {
+      const len = this.length;
+      if (len % 4 !== 0) {
+        throw new RangeError(\\"Buffer size must be a multiple of 32-bits\\");
+      }
+      for (let i = 0; i < len; i += 4) {
+        swap(this, i, i + 3);
+        swap(this, i + 1, i + 2);
+      }
+      return this;
+    };
+    Buffer2.prototype.swap64 = function swap64() {
+      const len = this.length;
+      if (len % 8 !== 0) {
+        throw new RangeError(\\"Buffer size must be a multiple of 64-bits\\");
+      }
+      for (let i = 0; i < len; i += 8) {
+        swap(this, i, i + 7);
+        swap(this, i + 1, i + 6);
+        swap(this, i + 2, i + 5);
+        swap(this, i + 3, i + 4);
+      }
+      return this;
+    };
+    Buffer2.prototype.toString = function toString() {
+      const length = this.length;
+      if (length === 0)
+        return \\"\\";
+      if (arguments.length === 0)
+        return utf8Slice(this, 0, length);
+      return slowToString.apply(this, arguments);
+    };
+    Buffer2.prototype.toLocaleString = Buffer2.prototype.toString;
+    Buffer2.prototype.equals = function equals(b) {
+      if (!Buffer2.isBuffer(b))
+        throw new TypeError(\\"Argument must be a Buffer\\");
+      if (this === b)
+        return true;
+      return Buffer2.compare(this, b) === 0;
+    };
+    Buffer2.prototype.inspect = function inspect() {
+      let str = \\"\\";
+      const max = exports$1.INSPECT_MAX_BYTES;
+      str = this.toString(\\"hex\\", 0, max).replace(/(.{2})/g, \\"$1 \\").trim();
+      if (this.length > max)
+        str += \\" ... \\";
+      return \\"<Buffer \\" + str + \\">\\";
+    };
+    if (customInspectSymbol) {
+      Buffer2.prototype[customInspectSymbol] = Buffer2.prototype.inspect;
+    }
+    Buffer2.prototype.compare = function compare(target, start, end, thisStart, thisEnd) {
+      if (isInstance(target, Uint8Array)) {
+        target = Buffer2.from(target, target.offset, target.byteLength);
+      }
+      if (!Buffer2.isBuffer(target)) {
+        throw new TypeError('The \\"target\\" argument must be one of type Buffer or Uint8Array. Received type ' + typeof target);
+      }
+      if (start === void 0) {
+        start = 0;
+      }
+      if (end === void 0) {
+        end = target ? target.length : 0;
+      }
+      if (thisStart === void 0) {
+        thisStart = 0;
+      }
+      if (thisEnd === void 0) {
+        thisEnd = this.length;
+      }
+      if (start < 0 || end > target.length || thisStart < 0 || thisEnd > this.length) {
+        throw new RangeError(\\"out of range index\\");
+      }
+      if (thisStart >= thisEnd && start >= end) {
+        return 0;
+      }
+      if (thisStart >= thisEnd) {
+        return -1;
+      }
+      if (start >= end) {
+        return 1;
+      }
+      start >>>= 0;
+      end >>>= 0;
+      thisStart >>>= 0;
+      thisEnd >>>= 0;
+      if (this === target)
+        return 0;
+      let x = thisEnd - thisStart;
+      let y = end - start;
+      const len = Math.min(x, y);
+      const thisCopy = this.slice(thisStart, thisEnd);
+      const targetCopy = target.slice(start, end);
+      for (let i = 0; i < len; ++i) {
+        if (thisCopy[i] !== targetCopy[i]) {
+          x = thisCopy[i];
+          y = targetCopy[i];
+          break;
+        }
+      }
+      if (x < y)
+        return -1;
+      if (y < x)
+        return 1;
+      return 0;
+    };
+    function bidirectionalIndexOf(buffer, val, byteOffset, encoding, dir) {
+      if (buffer.length === 0)
+        return -1;
+      if (typeof byteOffset === \\"string\\") {
+        encoding = byteOffset;
+        byteOffset = 0;
+      } else if (byteOffset > 2147483647) {
+        byteOffset = 2147483647;
+      } else if (byteOffset < -2147483648) {
+        byteOffset = -2147483648;
+      }
+      byteOffset = +byteOffset;
+      if (numberIsNaN(byteOffset)) {
+        byteOffset = dir ? 0 : buffer.length - 1;
+      }
+      if (byteOffset < 0)
+        byteOffset = buffer.length + byteOffset;
+      if (byteOffset >= buffer.length) {
+        if (dir)
+          return -1;
+        else
+          byteOffset = buffer.length - 1;
+      } else if (byteOffset < 0) {
+        if (dir)
+          byteOffset = 0;
+        else
+          return -1;
+      }
+      if (typeof val === \\"string\\") {
+        val = Buffer2.from(val, encoding);
+      }
+      if (Buffer2.isBuffer(val)) {
+        if (val.length === 0) {
+          return -1;
+        }
+        return arrayIndexOf(buffer, val, byteOffset, encoding, dir);
+      } else if (typeof val === \\"number\\") {
+        val = val & 255;
+        if (typeof Uint8Array.prototype.indexOf === \\"function\\") {
+          if (dir) {
+            return Uint8Array.prototype.indexOf.call(buffer, val, byteOffset);
+          } else {
+            return Uint8Array.prototype.lastIndexOf.call(buffer, val, byteOffset);
+          }
+        }
+        return arrayIndexOf(buffer, [val], byteOffset, encoding, dir);
+      }
+      throw new TypeError(\\"val must be string, number or Buffer\\");
+    }
+    function arrayIndexOf(arr, val, byteOffset, encoding, dir) {
+      let indexSize = 1;
+      let arrLength = arr.length;
+      let valLength = val.length;
+      if (encoding !== void 0) {
+        encoding = String(encoding).toLowerCase();
+        if (encoding === \\"ucs2\\" || encoding === \\"ucs-2\\" || encoding === \\"utf16le\\" || encoding === \\"utf-16le\\") {
+          if (arr.length < 2 || val.length < 2) {
+            return -1;
+          }
+          indexSize = 2;
+          arrLength /= 2;
+          valLength /= 2;
+          byteOffset /= 2;
+        }
+      }
+      function read(buf, i2) {
+        if (indexSize === 1) {
+          return buf[i2];
+        } else {
+          return buf.readUInt16BE(i2 * indexSize);
+        }
+      }
+      let i;
+      if (dir) {
+        let foundIndex = -1;
+        for (i = byteOffset; i < arrLength; i++) {
+          if (read(arr, i) === read(val, foundIndex === -1 ? 0 : i - foundIndex)) {
+            if (foundIndex === -1)
+              foundIndex = i;
+            if (i - foundIndex + 1 === valLength)
+              return foundIndex * indexSize;
+          } else {
+            if (foundIndex !== -1)
+              i -= i - foundIndex;
+            foundIndex = -1;
+          }
+        }
+      } else {
+        if (byteOffset + valLength > arrLength)
+          byteOffset = arrLength - valLength;
+        for (i = byteOffset; i >= 0; i--) {
+          let found = true;
+          for (let j = 0; j < valLength; j++) {
+            if (read(arr, i + j) !== read(val, j)) {
+              found = false;
+              break;
+            }
+          }
+          if (found)
+            return i;
+        }
+      }
+      return -1;
+    }
+    Buffer2.prototype.includes = function includes(val, byteOffset, encoding) {
+      return this.indexOf(val, byteOffset, encoding) !== -1;
+    };
+    Buffer2.prototype.indexOf = function indexOf(val, byteOffset, encoding) {
+      return bidirectionalIndexOf(this, val, byteOffset, encoding, true);
+    };
+    Buffer2.prototype.lastIndexOf = function lastIndexOf(val, byteOffset, encoding) {
+      return bidirectionalIndexOf(this, val, byteOffset, encoding, false);
+    };
+    function hexWrite(buf, string, offset, length) {
+      offset = Number(offset) || 0;
+      const remaining = buf.length - offset;
+      if (!length) {
+        length = remaining;
+      } else {
+        length = Number(length);
+        if (length > remaining) {
+          length = remaining;
+        }
+      }
+      const strLen = string.length;
+      if (length > strLen / 2) {
+        length = strLen / 2;
+      }
+      let i;
+      for (i = 0; i < length; ++i) {
+        const parsed = parseInt(string.substr(i * 2, 2), 16);
+        if (numberIsNaN(parsed))
+          return i;
+        buf[offset + i] = parsed;
+      }
+      return i;
+    }
+    function utf8Write(buf, string, offset, length) {
+      return blitBuffer(utf8ToBytes(string, buf.length - offset), buf, offset, length);
+    }
+    function asciiWrite(buf, string, offset, length) {
+      return blitBuffer(asciiToBytes(string), buf, offset, length);
+    }
+    function base64Write(buf, string, offset, length) {
+      return blitBuffer(base64ToBytes(string), buf, offset, length);
+    }
+    function ucs2Write(buf, string, offset, length) {
+      return blitBuffer(utf16leToBytes(string, buf.length - offset), buf, offset, length);
+    }
+    Buffer2.prototype.write = function write(string, offset, length, encoding) {
+      if (offset === void 0) {
+        encoding = \\"utf8\\";
+        length = this.length;
+        offset = 0;
+      } else if (length === void 0 && typeof offset === \\"string\\") {
+        encoding = offset;
+        length = this.length;
+        offset = 0;
+      } else if (isFinite(offset)) {
+        offset = offset >>> 0;
+        if (isFinite(length)) {
+          length = length >>> 0;
+          if (encoding === void 0)
+            encoding = \\"utf8\\";
+        } else {
+          encoding = length;
+          length = void 0;
+        }
+      } else {
+        throw new Error(\\"Buffer.write(string, encoding, offset[, length]) is no longer supported\\");
+      }
+      const remaining = this.length - offset;
+      if (length === void 0 || length > remaining)
+        length = remaining;
+      if (string.length > 0 && (length < 0 || offset < 0) || offset > this.length) {
+        throw new RangeError(\\"Attempt to write outside buffer bounds\\");
+      }
+      if (!encoding)
+        encoding = \\"utf8\\";
+      let loweredCase = false;
+      for (; ; ) {
+        switch (encoding) {
+          case \\"hex\\":
+            return hexWrite(this, string, offset, length);
+          case \\"utf8\\":
+          case \\"utf-8\\":
+            return utf8Write(this, string, offset, length);
+          case \\"ascii\\":
+          case \\"latin1\\":
+          case \\"binary\\":
+            return asciiWrite(this, string, offset, length);
+          case \\"base64\\":
+            return base64Write(this, string, offset, length);
+          case \\"ucs2\\":
+          case \\"ucs-2\\":
+          case \\"utf16le\\":
+          case \\"utf-16le\\":
+            return ucs2Write(this, string, offset, length);
+          default:
+            if (loweredCase)
+              throw new TypeError(\\"Unknown encoding: \\" + encoding);
+            encoding = (\\"\\" + encoding).toLowerCase();
+            loweredCase = true;
+        }
+      }
+    };
+    Buffer2.prototype.toJSON = function toJSON() {
+      return {
+        type: \\"Buffer\\",
+        data: Array.prototype.slice.call(this._arr || this, 0)
+      };
+    };
+    function base64Slice(buf, start, end) {
+      if (start === 0 && end === buf.length) {
+        return base64.fromByteArray(buf);
+      } else {
+        return base64.fromByteArray(buf.slice(start, end));
+      }
+    }
+    function utf8Slice(buf, start, end) {
+      end = Math.min(buf.length, end);
+      const res = [];
+      let i = start;
+      while (i < end) {
+        const firstByte = buf[i];
+        let codePoint = null;
+        let bytesPerSequence = firstByte > 239 ? 4 : firstByte > 223 ? 3 : firstByte > 191 ? 2 : 1;
+        if (i + bytesPerSequence <= end) {
+          let secondByte, thirdByte, fourthByte, tempCodePoint;
+          switch (bytesPerSequence) {
+            case 1:
+              if (firstByte < 128) {
+                codePoint = firstByte;
+              }
+              break;
+            case 2:
+              secondByte = buf[i + 1];
+              if ((secondByte & 192) === 128) {
+                tempCodePoint = (firstByte & 31) << 6 | secondByte & 63;
+                if (tempCodePoint > 127) {
+                  codePoint = tempCodePoint;
+                }
+              }
+              break;
+            case 3:
+              secondByte = buf[i + 1];
+              thirdByte = buf[i + 2];
+              if ((secondByte & 192) === 128 && (thirdByte & 192) === 128) {
+                tempCodePoint = (firstByte & 15) << 12 | (secondByte & 63) << 6 | thirdByte & 63;
+                if (tempCodePoint > 2047 && (tempCodePoint < 55296 || tempCodePoint > 57343)) {
+                  codePoint = tempCodePoint;
+                }
+              }
+              break;
+            case 4:
+              secondByte = buf[i + 1];
+              thirdByte = buf[i + 2];
+              fourthByte = buf[i + 3];
+              if ((secondByte & 192) === 128 && (thirdByte & 192) === 128 && (fourthByte & 192) === 128) {
+                tempCodePoint = (firstByte & 15) << 18 | (secondByte & 63) << 12 | (thirdByte & 63) << 6 | fourthByte & 63;
+                if (tempCodePoint > 65535 && tempCodePoint < 1114112) {
+                  codePoint = tempCodePoint;
+                }
+              }
+          }
+        }
+        if (codePoint === null) {
+          codePoint = 65533;
+          bytesPerSequence = 1;
+        } else if (codePoint > 65535) {
+          codePoint -= 65536;
+          res.push(codePoint >>> 10 & 1023 | 55296);
+          codePoint = 56320 | codePoint & 1023;
+        }
+        res.push(codePoint);
+        i += bytesPerSequence;
+      }
+      return decodeCodePointsArray(res);
+    }
+    const MAX_ARGUMENTS_LENGTH = 4096;
+    function decodeCodePointsArray(codePoints) {
+      const len = codePoints.length;
+      if (len <= MAX_ARGUMENTS_LENGTH) {
+        return String.fromCharCode.apply(String, codePoints);
+      }
+      let res = \\"\\";
+      let i = 0;
+      while (i < len) {
+        res += String.fromCharCode.apply(String, codePoints.slice(i, i += MAX_ARGUMENTS_LENGTH));
+      }
+      return res;
+    }
+    function asciiSlice(buf, start, end) {
+      let ret = \\"\\";
+      end = Math.min(buf.length, end);
+      for (let i = start; i < end; ++i) {
+        ret += String.fromCharCode(buf[i] & 127);
+      }
+      return ret;
+    }
+    function latin1Slice(buf, start, end) {
+      let ret = \\"\\";
+      end = Math.min(buf.length, end);
+      for (let i = start; i < end; ++i) {
+        ret += String.fromCharCode(buf[i]);
+      }
+      return ret;
+    }
+    function hexSlice(buf, start, end) {
+      const len = buf.length;
+      if (!start || start < 0)
+        start = 0;
+      if (!end || end < 0 || end > len)
+        end = len;
+      let out = \\"\\";
+      for (let i = start; i < end; ++i) {
+        out += hexSliceLookupTable[buf[i]];
+      }
+      return out;
+    }
+    function utf16leSlice(buf, start, end) {
+      const bytes = buf.slice(start, end);
+      let res = \\"\\";
+      for (let i = 0; i < bytes.length - 1; i += 2) {
+        res += String.fromCharCode(bytes[i] + bytes[i + 1] * 256);
+      }
+      return res;
+    }
+    Buffer2.prototype.slice = function slice(start, end) {
+      const len = this.length;
+      start = ~~start;
+      end = end === void 0 ? len : ~~end;
+      if (start < 0) {
+        start += len;
+        if (start < 0)
+          start = 0;
+      } else if (start > len) {
+        start = len;
+      }
+      if (end < 0) {
+        end += len;
+        if (end < 0)
+          end = 0;
+      } else if (end > len) {
+        end = len;
+      }
+      if (end < start)
+        end = start;
+      const newBuf = this.subarray(start, end);
+      Object.setPrototypeOf(newBuf, Buffer2.prototype);
+      return newBuf;
+    };
+    function checkOffset(offset, ext, length) {
+      if (offset % 1 !== 0 || offset < 0)
+        throw new RangeError(\\"offset is not uint\\");
+      if (offset + ext > length)
+        throw new RangeError(\\"Trying to access beyond buffer length\\");
+    }
+    Buffer2.prototype.readUintLE = Buffer2.prototype.readUIntLE = function readUIntLE(offset, byteLength2, noAssert) {
+      offset = offset >>> 0;
+      byteLength2 = byteLength2 >>> 0;
+      if (!noAssert)
+        checkOffset(offset, byteLength2, this.length);
+      let val = this[offset];
+      let mul = 1;
+      let i = 0;
+      while (++i < byteLength2 && (mul *= 256)) {
+        val += this[offset + i] * mul;
+      }
+      return val;
+    };
+    Buffer2.prototype.readUintBE = Buffer2.prototype.readUIntBE = function readUIntBE(offset, byteLength2, noAssert) {
+      offset = offset >>> 0;
+      byteLength2 = byteLength2 >>> 0;
+      if (!noAssert) {
+        checkOffset(offset, byteLength2, this.length);
+      }
+      let val = this[offset + --byteLength2];
+      let mul = 1;
+      while (byteLength2 > 0 && (mul *= 256)) {
+        val += this[offset + --byteLength2] * mul;
+      }
+      return val;
+    };
+    Buffer2.prototype.readUint8 = Buffer2.prototype.readUInt8 = function readUInt8(offset, noAssert) {
+      offset = offset >>> 0;
+      if (!noAssert)
+        checkOffset(offset, 1, this.length);
+      return this[offset];
+    };
+    Buffer2.prototype.readUint16LE = Buffer2.prototype.readUInt16LE = function readUInt16LE(offset, noAssert) {
+      offset = offset >>> 0;
+      if (!noAssert)
+        checkOffset(offset, 2, this.length);
+      return this[offset] | this[offset + 1] << 8;
+    };
+    Buffer2.prototype.readUint16BE = Buffer2.prototype.readUInt16BE = function readUInt16BE(offset, noAssert) {
+      offset = offset >>> 0;
+      if (!noAssert)
+        checkOffset(offset, 2, this.length);
+      return this[offset] << 8 | this[offset + 1];
+    };
+    Buffer2.prototype.readUint32LE = Buffer2.prototype.readUInt32LE = function readUInt32LE(offset, noAssert) {
+      offset = offset >>> 0;
+      if (!noAssert)
+        checkOffset(offset, 4, this.length);
+      return (this[offset] | this[offset + 1] << 8 | this[offset + 2] << 16) + this[offset + 3] * 16777216;
+    };
+    Buffer2.prototype.readUint32BE = Buffer2.prototype.readUInt32BE = function readUInt32BE(offset, noAssert) {
+      offset = offset >>> 0;
+      if (!noAssert)
+        checkOffset(offset, 4, this.length);
+      return this[offset] * 16777216 + (this[offset + 1] << 16 | this[offset + 2] << 8 | this[offset + 3]);
+    };
+    Buffer2.prototype.readBigUInt64LE = defineBigIntMethod(function readBigUInt64LE(offset) {
+      offset = offset >>> 0;
+      validateNumber(offset, \\"offset\\");
+      const first = this[offset];
+      const last = this[offset + 7];
+      if (first === void 0 || last === void 0) {
+        boundsError(offset, this.length - 8);
+      }
+      const lo = first + this[++offset] * 2 ** 8 + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 24;
+      const hi = this[++offset] + this[++offset] * 2 ** 8 + this[++offset] * 2 ** 16 + last * 2 ** 24;
+      return BigInt(lo) + (BigInt(hi) << BigInt(32));
+    });
+    Buffer2.prototype.readBigUInt64BE = defineBigIntMethod(function readBigUInt64BE(offset) {
+      offset = offset >>> 0;
+      validateNumber(offset, \\"offset\\");
+      const first = this[offset];
+      const last = this[offset + 7];
+      if (first === void 0 || last === void 0) {
+        boundsError(offset, this.length - 8);
+      }
+      const hi = first * 2 ** 24 + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 8 + this[++offset];
+      const lo = this[++offset] * 2 ** 24 + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 8 + last;
+      return (BigInt(hi) << BigInt(32)) + BigInt(lo);
+    });
+    Buffer2.prototype.readIntLE = function readIntLE(offset, byteLength2, noAssert) {
+      offset = offset >>> 0;
+      byteLength2 = byteLength2 >>> 0;
+      if (!noAssert)
+        checkOffset(offset, byteLength2, this.length);
+      let val = this[offset];
+      let mul = 1;
+      let i = 0;
+      while (++i < byteLength2 && (mul *= 256)) {
+        val += this[offset + i] * mul;
+      }
+      mul *= 128;
+      if (val >= mul)
+        val -= Math.pow(2, 8 * byteLength2);
+      return val;
+    };
+    Buffer2.prototype.readIntBE = function readIntBE(offset, byteLength2, noAssert) {
+      offset = offset >>> 0;
+      byteLength2 = byteLength2 >>> 0;
+      if (!noAssert)
+        checkOffset(offset, byteLength2, this.length);
+      let i = byteLength2;
+      let mul = 1;
+      let val = this[offset + --i];
+      while (i > 0 && (mul *= 256)) {
+        val += this[offset + --i] * mul;
+      }
+      mul *= 128;
+      if (val >= mul)
+        val -= Math.pow(2, 8 * byteLength2);
+      return val;
+    };
+    Buffer2.prototype.readInt8 = function readInt8(offset, noAssert) {
+      offset = offset >>> 0;
+      if (!noAssert)
+        checkOffset(offset, 1, this.length);
+      if (!(this[offset] & 128))
+        return this[offset];
+      return (255 - this[offset] + 1) * -1;
+    };
+    Buffer2.prototype.readInt16LE = function readInt16LE(offset, noAssert) {
+      offset = offset >>> 0;
+      if (!noAssert)
+        checkOffset(offset, 2, this.length);
+      const val = this[offset] | this[offset + 1] << 8;
+      return val & 32768 ? val | 4294901760 : val;
+    };
+    Buffer2.prototype.readInt16BE = function readInt16BE(offset, noAssert) {
+      offset = offset >>> 0;
+      if (!noAssert)
+        checkOffset(offset, 2, this.length);
+      const val = this[offset + 1] | this[offset] << 8;
+      return val & 32768 ? val | 4294901760 : val;
+    };
+    Buffer2.prototype.readInt32LE = function readInt32LE(offset, noAssert) {
+      offset = offset >>> 0;
+      if (!noAssert)
+        checkOffset(offset, 4, this.length);
+      return this[offset] | this[offset + 1] << 8 | this[offset + 2] << 16 | this[offset + 3] << 24;
+    };
+    Buffer2.prototype.readInt32BE = function readInt32BE(offset, noAssert) {
+      offset = offset >>> 0;
+      if (!noAssert)
+        checkOffset(offset, 4, this.length);
+      return this[offset] << 24 | this[offset + 1] << 16 | this[offset + 2] << 8 | this[offset + 3];
+    };
+    Buffer2.prototype.readBigInt64LE = defineBigIntMethod(function readBigInt64LE(offset) {
+      offset = offset >>> 0;
+      validateNumber(offset, \\"offset\\");
+      const first = this[offset];
+      const last = this[offset + 7];
+      if (first === void 0 || last === void 0) {
+        boundsError(offset, this.length - 8);
+      }
+      const val = this[offset + 4] + this[offset + 5] * 2 ** 8 + this[offset + 6] * 2 ** 16 + (last << 24);
+      return (BigInt(val) << BigInt(32)) + BigInt(first + this[++offset] * 2 ** 8 + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 24);
+    });
+    Buffer2.prototype.readBigInt64BE = defineBigIntMethod(function readBigInt64BE(offset) {
+      offset = offset >>> 0;
+      validateNumber(offset, \\"offset\\");
+      const first = this[offset];
+      const last = this[offset + 7];
+      if (first === void 0 || last === void 0) {
+        boundsError(offset, this.length - 8);
+      }
+      const val = (first << 24) + // Overflow
+      this[++offset] * 2 ** 16 + this[++offset] * 2 ** 8 + this[++offset];
+      return (BigInt(val) << BigInt(32)) + BigInt(this[++offset] * 2 ** 24 + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 8 + last);
+    });
+    Buffer2.prototype.readFloatLE = function readFloatLE(offset, noAssert) {
+      offset = offset >>> 0;
+      if (!noAssert)
+        checkOffset(offset, 4, this.length);
+      return ieee754.read(this, offset, true, 23, 4);
+    };
+    Buffer2.prototype.readFloatBE = function readFloatBE(offset, noAssert) {
+      offset = offset >>> 0;
+      if (!noAssert)
+        checkOffset(offset, 4, this.length);
+      return ieee754.read(this, offset, false, 23, 4);
+    };
+    Buffer2.prototype.readDoubleLE = function readDoubleLE(offset, noAssert) {
+      offset = offset >>> 0;
+      if (!noAssert)
+        checkOffset(offset, 8, this.length);
+      return ieee754.read(this, offset, true, 52, 8);
+    };
+    Buffer2.prototype.readDoubleBE = function readDoubleBE(offset, noAssert) {
+      offset = offset >>> 0;
+      if (!noAssert)
+        checkOffset(offset, 8, this.length);
+      return ieee754.read(this, offset, false, 52, 8);
+    };
+    function checkInt(buf, value, offset, ext, max, min) {
+      if (!Buffer2.isBuffer(buf))
+        throw new TypeError('\\"buffer\\" argument must be a Buffer instance');
+      if (value > max || value < min)
+        throw new RangeError('\\"value\\" argument is out of bounds');
+      if (offset + ext > buf.length)
+        throw new RangeError(\\"Index out of range\\");
+    }
+    Buffer2.prototype.writeUintLE = Buffer2.prototype.writeUIntLE = function writeUIntLE(value, offset, byteLength2, noAssert) {
+      value = +value;
+      offset = offset >>> 0;
+      byteLength2 = byteLength2 >>> 0;
+      if (!noAssert) {
+        const maxBytes = Math.pow(2, 8 * byteLength2) - 1;
+        checkInt(this, value, offset, byteLength2, maxBytes, 0);
+      }
+      let mul = 1;
+      let i = 0;
+      this[offset] = value & 255;
+      while (++i < byteLength2 && (mul *= 256)) {
+        this[offset + i] = value / mul & 255;
+      }
+      return offset + byteLength2;
+    };
+    Buffer2.prototype.writeUintBE = Buffer2.prototype.writeUIntBE = function writeUIntBE(value, offset, byteLength2, noAssert) {
+      value = +value;
+      offset = offset >>> 0;
+      byteLength2 = byteLength2 >>> 0;
+      if (!noAssert) {
+        const maxBytes = Math.pow(2, 8 * byteLength2) - 1;
+        checkInt(this, value, offset, byteLength2, maxBytes, 0);
+      }
+      let i = byteLength2 - 1;
+      let mul = 1;
+      this[offset + i] = value & 255;
+      while (--i >= 0 && (mul *= 256)) {
+        this[offset + i] = value / mul & 255;
+      }
+      return offset + byteLength2;
+    };
+    Buffer2.prototype.writeUint8 = Buffer2.prototype.writeUInt8 = function writeUInt8(value, offset, noAssert) {
+      value = +value;
+      offset = offset >>> 0;
+      if (!noAssert)
+        checkInt(this, value, offset, 1, 255, 0);
+      this[offset] = value & 255;
+      return offset + 1;
+    };
+    Buffer2.prototype.writeUint16LE = Buffer2.prototype.writeUInt16LE = function writeUInt16LE(value, offset, noAssert) {
+      value = +value;
+      offset = offset >>> 0;
+      if (!noAssert)
+        checkInt(this, value, offset, 2, 65535, 0);
+      this[offset] = value & 255;
+      this[offset + 1] = value >>> 8;
+      return offset + 2;
+    };
+    Buffer2.prototype.writeUint16BE = Buffer2.prototype.writeUInt16BE = function writeUInt16BE(value, offset, noAssert) {
+      value = +value;
+      offset = offset >>> 0;
+      if (!noAssert)
+        checkInt(this, value, offset, 2, 65535, 0);
+      this[offset] = value >>> 8;
+      this[offset + 1] = value & 255;
+      return offset + 2;
+    };
+    Buffer2.prototype.writeUint32LE = Buffer2.prototype.writeUInt32LE = function writeUInt32LE(value, offset, noAssert) {
+      value = +value;
+      offset = offset >>> 0;
+      if (!noAssert)
+        checkInt(this, value, offset, 4, 4294967295, 0);
+      this[offset + 3] = value >>> 24;
+      this[offset + 2] = value >>> 16;
+      this[offset + 1] = value >>> 8;
+      this[offset] = value & 255;
+      return offset + 4;
+    };
+    Buffer2.prototype.writeUint32BE = Buffer2.prototype.writeUInt32BE = function writeUInt32BE(value, offset, noAssert) {
+      value = +value;
+      offset = offset >>> 0;
+      if (!noAssert)
+        checkInt(this, value, offset, 4, 4294967295, 0);
+      this[offset] = value >>> 24;
+      this[offset + 1] = value >>> 16;
+      this[offset + 2] = value >>> 8;
+      this[offset + 3] = value & 255;
+      return offset + 4;
+    };
+    function wrtBigUInt64LE(buf, value, offset, min, max) {
+      checkIntBI(value, min, max, buf, offset, 7);
+      let lo = Number(value & BigInt(4294967295));
+      buf[offset++] = lo;
+      lo = lo >> 8;
+      buf[offset++] = lo;
+      lo = lo >> 8;
+      buf[offset++] = lo;
+      lo = lo >> 8;
+      buf[offset++] = lo;
+      let hi = Number(value >> BigInt(32) & BigInt(4294967295));
+      buf[offset++] = hi;
+      hi = hi >> 8;
+      buf[offset++] = hi;
+      hi = hi >> 8;
+      buf[offset++] = hi;
+      hi = hi >> 8;
+      buf[offset++] = hi;
+      return offset;
+    }
+    function wrtBigUInt64BE(buf, value, offset, min, max) {
+      checkIntBI(value, min, max, buf, offset, 7);
+      let lo = Number(value & BigInt(4294967295));
+      buf[offset + 7] = lo;
+      lo = lo >> 8;
+      buf[offset + 6] = lo;
+      lo = lo >> 8;
+      buf[offset + 5] = lo;
+      lo = lo >> 8;
+      buf[offset + 4] = lo;
+      let hi = Number(value >> BigInt(32) & BigInt(4294967295));
+      buf[offset + 3] = hi;
+      hi = hi >> 8;
+      buf[offset + 2] = hi;
+      hi = hi >> 8;
+      buf[offset + 1] = hi;
+      hi = hi >> 8;
+      buf[offset] = hi;
+      return offset + 8;
+    }
+    Buffer2.prototype.writeBigUInt64LE = defineBigIntMethod(function writeBigUInt64LE(value, offset = 0) {
+      return wrtBigUInt64LE(this, value, offset, BigInt(0), BigInt(\\"0xffffffffffffffff\\"));
+    });
+    Buffer2.prototype.writeBigUInt64BE = defineBigIntMethod(function writeBigUInt64BE(value, offset = 0) {
+      return wrtBigUInt64BE(this, value, offset, BigInt(0), BigInt(\\"0xffffffffffffffff\\"));
+    });
+    Buffer2.prototype.writeIntLE = function writeIntLE(value, offset, byteLength2, noAssert) {
+      value = +value;
+      offset = offset >>> 0;
+      if (!noAssert) {
+        const limit = Math.pow(2, 8 * byteLength2 - 1);
+        checkInt(this, value, offset, byteLength2, limit - 1, -limit);
+      }
+      let i = 0;
+      let mul = 1;
+      let sub = 0;
+      this[offset] = value & 255;
+      while (++i < byteLength2 && (mul *= 256)) {
+        if (value < 0 && sub === 0 && this[offset + i - 1] !== 0) {
+          sub = 1;
+        }
+        this[offset + i] = (value / mul >> 0) - sub & 255;
+      }
+      return offset + byteLength2;
+    };
+    Buffer2.prototype.writeIntBE = function writeIntBE(value, offset, byteLength2, noAssert) {
+      value = +value;
+      offset = offset >>> 0;
+      if (!noAssert) {
+        const limit = Math.pow(2, 8 * byteLength2 - 1);
+        checkInt(this, value, offset, byteLength2, limit - 1, -limit);
+      }
+      let i = byteLength2 - 1;
+      let mul = 1;
+      let sub = 0;
+      this[offset + i] = value & 255;
+      while (--i >= 0 && (mul *= 256)) {
+        if (value < 0 && sub === 0 && this[offset + i + 1] !== 0) {
+          sub = 1;
+        }
+        this[offset + i] = (value / mul >> 0) - sub & 255;
+      }
+      return offset + byteLength2;
+    };
+    Buffer2.prototype.writeInt8 = function writeInt8(value, offset, noAssert) {
+      value = +value;
+      offset = offset >>> 0;
+      if (!noAssert)
+        checkInt(this, value, offset, 1, 127, -128);
+      if (value < 0)
+        value = 255 + value + 1;
+      this[offset] = value & 255;
+      return offset + 1;
+    };
+    Buffer2.prototype.writeInt16LE = function writeInt16LE(value, offset, noAssert) {
+      value = +value;
+      offset = offset >>> 0;
+      if (!noAssert)
+        checkInt(this, value, offset, 2, 32767, -32768);
+      this[offset] = value & 255;
+      this[offset + 1] = value >>> 8;
+      return offset + 2;
+    };
+    Buffer2.prototype.writeInt16BE = function writeInt16BE(value, offset, noAssert) {
+      value = +value;
+      offset = offset >>> 0;
+      if (!noAssert)
+        checkInt(this, value, offset, 2, 32767, -32768);
+      this[offset] = value >>> 8;
+      this[offset + 1] = value & 255;
+      return offset + 2;
+    };
+    Buffer2.prototype.writeInt32LE = function writeInt32LE(value, offset, noAssert) {
+      value = +value;
+      offset = offset >>> 0;
+      if (!noAssert)
+        checkInt(this, value, offset, 4, 2147483647, -2147483648);
+      this[offset] = value & 255;
+      this[offset + 1] = value >>> 8;
+      this[offset + 2] = value >>> 16;
+      this[offset + 3] = value >>> 24;
+      return offset + 4;
+    };
+    Buffer2.prototype.writeInt32BE = function writeInt32BE(value, offset, noAssert) {
+      value = +value;
+      offset = offset >>> 0;
+      if (!noAssert)
+        checkInt(this, value, offset, 4, 2147483647, -2147483648);
+      if (value < 0)
+        value = 4294967295 + value + 1;
+      this[offset] = value >>> 24;
+      this[offset + 1] = value >>> 16;
+      this[offset + 2] = value >>> 8;
+      this[offset + 3] = value & 255;
+      return offset + 4;
+    };
+    Buffer2.prototype.writeBigInt64LE = defineBigIntMethod(function writeBigInt64LE(value, offset = 0) {
+      return wrtBigUInt64LE(this, value, offset, -BigInt(\\"0x8000000000000000\\"), BigInt(\\"0x7fffffffffffffff\\"));
+    });
+    Buffer2.prototype.writeBigInt64BE = defineBigIntMethod(function writeBigInt64BE(value, offset = 0) {
+      return wrtBigUInt64BE(this, value, offset, -BigInt(\\"0x8000000000000000\\"), BigInt(\\"0x7fffffffffffffff\\"));
+    });
+    function checkIEEE754(buf, value, offset, ext, max, min) {
+      if (offset + ext > buf.length)
+        throw new RangeError(\\"Index out of range\\");
+      if (offset < 0)
+        throw new RangeError(\\"Index out of range\\");
+    }
+    function writeFloat(buf, value, offset, littleEndian, noAssert) {
+      value = +value;
+      offset = offset >>> 0;
+      if (!noAssert) {
+        checkIEEE754(buf, value, offset, 4);
+      }
+      ieee754.write(buf, value, offset, littleEndian, 23, 4);
+      return offset + 4;
+    }
+    Buffer2.prototype.writeFloatLE = function writeFloatLE(value, offset, noAssert) {
+      return writeFloat(this, value, offset, true, noAssert);
+    };
+    Buffer2.prototype.writeFloatBE = function writeFloatBE(value, offset, noAssert) {
+      return writeFloat(this, value, offset, false, noAssert);
+    };
+    function writeDouble(buf, value, offset, littleEndian, noAssert) {
+      value = +value;
+      offset = offset >>> 0;
+      if (!noAssert) {
+        checkIEEE754(buf, value, offset, 8);
+      }
+      ieee754.write(buf, value, offset, littleEndian, 52, 8);
+      return offset + 8;
+    }
+    Buffer2.prototype.writeDoubleLE = function writeDoubleLE(value, offset, noAssert) {
+      return writeDouble(this, value, offset, true, noAssert);
+    };
+    Buffer2.prototype.writeDoubleBE = function writeDoubleBE(value, offset, noAssert) {
+      return writeDouble(this, value, offset, false, noAssert);
+    };
+    Buffer2.prototype.copy = function copy(target, targetStart, start, end) {
+      if (!Buffer2.isBuffer(target))
+        throw new TypeError(\\"argument should be a Buffer\\");
+      if (!start)
+        start = 0;
+      if (!end && end !== 0)
+        end = this.length;
+      if (targetStart >= target.length)
+        targetStart = target.length;
+      if (!targetStart)
+        targetStart = 0;
+      if (end > 0 && end < start)
+        end = start;
+      if (end === start)
+        return 0;
+      if (target.length === 0 || this.length === 0)
+        return 0;
+      if (targetStart < 0) {
+        throw new RangeError(\\"targetStart out of bounds\\");
+      }
+      if (start < 0 || start >= this.length)
+        throw new RangeError(\\"Index out of range\\");
+      if (end < 0)
+        throw new RangeError(\\"sourceEnd out of bounds\\");
+      if (end > this.length)
+        end = this.length;
+      if (target.length - targetStart < end - start) {
+        end = target.length - targetStart + start;
+      }
+      const len = end - start;
+      if (this === target && typeof Uint8Array.prototype.copyWithin === \\"function\\") {
+        this.copyWithin(targetStart, start, end);
+      } else {
+        Uint8Array.prototype.set.call(target, this.subarray(start, end), targetStart);
+      }
+      return len;
+    };
+    Buffer2.prototype.fill = function fill(val, start, end, encoding) {
+      if (typeof val === \\"string\\") {
+        if (typeof start === \\"string\\") {
+          encoding = start;
+          start = 0;
+          end = this.length;
+        } else if (typeof end === \\"string\\") {
+          encoding = end;
+          end = this.length;
+        }
+        if (encoding !== void 0 && typeof encoding !== \\"string\\") {
+          throw new TypeError(\\"encoding must be a string\\");
+        }
+        if (typeof encoding === \\"string\\" && !Buffer2.isEncoding(encoding)) {
+          throw new TypeError(\\"Unknown encoding: \\" + encoding);
+        }
+        if (val.length === 1) {
+          const code = val.charCodeAt(0);
+          if (encoding === \\"utf8\\" && code < 128 || encoding === \\"latin1\\") {
+            val = code;
+          }
+        }
+      } else if (typeof val === \\"number\\") {
+        val = val & 255;
+      } else if (typeof val === \\"boolean\\") {
+        val = Number(val);
+      }
+      if (start < 0 || this.length < start || this.length < end) {
+        throw new RangeError(\\"Out of range index\\");
+      }
+      if (end <= start) {
+        return this;
+      }
+      start = start >>> 0;
+      end = end === void 0 ? this.length : end >>> 0;
+      if (!val)
+        val = 0;
+      let i;
+      if (typeof val === \\"number\\") {
+        for (i = start; i < end; ++i) {
+          this[i] = val;
+        }
+      } else {
+        const bytes = Buffer2.isBuffer(val) ? val : Buffer2.from(val, encoding);
+        const len = bytes.length;
+        if (len === 0) {
+          throw new TypeError('The value \\"' + val + '\\" is invalid for argument \\"value\\"');
+        }
+        for (i = 0; i < end - start; ++i) {
+          this[i + start] = bytes[i % len];
+        }
+      }
+      return this;
+    };
+    const errors = {};
+    function E(sym, getMessage, Base) {
+      errors[sym] = class NodeError extends Base {
+        constructor() {
+          super();
+          Object.defineProperty(this, \\"message\\", {
+            value: getMessage.apply(this, arguments),
+            writable: true,
+            configurable: true
+          });
+          this.name = \`\${this.name} [\${sym}]\`;
+          this.stack;
+          delete this.name;
+        }
+        get code() {
+          return sym;
+        }
+        set code(value) {
+          Object.defineProperty(this, \\"code\\", {
+            configurable: true,
+            enumerable: true,
+            value,
+            writable: true
+          });
+        }
+        toString() {
+          return \`\${this.name} [\${sym}]: \${this.message}\`;
+        }
+      };
+    }
+    E(\\"ERR_BUFFER_OUT_OF_BOUNDS\\", function(name) {
+      if (name) {
+        return \`\${name} is outside of buffer bounds\`;
+      }
+      return \\"Attempt to access memory outside buffer bounds\\";
+    }, RangeError);
+    E(\\"ERR_INVALID_ARG_TYPE\\", function(name, actual) {
+      return \`The \\"\${name}\\" argument must be of type number. Received type \${typeof actual}\`;
+    }, TypeError);
+    E(\\"ERR_OUT_OF_RANGE\\", function(str, range, input) {
+      let msg = \`The value of \\"\${str}\\" is out of range.\`;
+      let received = input;
+      if (Number.isInteger(input) && Math.abs(input) > 2 ** 32) {
+        received = addNumericalSeparator(String(input));
+      } else if (typeof input === \\"bigint\\") {
+        received = String(input);
+        if (input > BigInt(2) ** BigInt(32) || input < -(BigInt(2) ** BigInt(32))) {
+          received = addNumericalSeparator(received);
+        }
+        received += \\"n\\";
+      }
+      msg += \` It must be \${range}. Received \${received}\`;
+      return msg;
+    }, RangeError);
+    function addNumericalSeparator(val) {
+      let res = \\"\\";
+      let i = val.length;
+      const start = val[0] === \\"-\\" ? 1 : 0;
+      for (; i >= start + 4; i -= 3) {
+        res = \`_\${val.slice(i - 3, i)}\${res}\`;
+      }
+      return \`\${val.slice(0, i)}\${res}\`;
+    }
+    function checkBounds(buf, offset, byteLength2) {
+      validateNumber(offset, \\"offset\\");
+      if (buf[offset] === void 0 || buf[offset + byteLength2] === void 0) {
+        boundsError(offset, buf.length - (byteLength2 + 1));
+      }
+    }
+    function checkIntBI(value, min, max, buf, offset, byteLength2) {
+      if (value > max || value < min) {
+        const n = typeof min === \\"bigint\\" ? \\"n\\" : \\"\\";
+        let range;
+        if (byteLength2 > 3) {
+          if (min === 0 || min === BigInt(0)) {
+            range = \`>= 0\${n} and < 2\${n} ** \${(byteLength2 + 1) * 8}\${n}\`;
+          } else {
+            range = \`>= -(2\${n} ** \${(byteLength2 + 1) * 8 - 1}\${n}) and < 2 ** \${(byteLength2 + 1) * 8 - 1}\${n}\`;
+          }
+        } else {
+          range = \`>= \${min}\${n} and <= \${max}\${n}\`;
+        }
+        throw new errors.ERR_OUT_OF_RANGE(\\"value\\", range, value);
+      }
+      checkBounds(buf, offset, byteLength2);
+    }
+    function validateNumber(value, name) {
+      if (typeof value !== \\"number\\") {
+        throw new errors.ERR_INVALID_ARG_TYPE(name, \\"number\\", value);
+      }
+    }
+    function boundsError(value, length, type) {
+      if (Math.floor(value) !== value) {
+        validateNumber(value, type);
+        throw new errors.ERR_OUT_OF_RANGE(type || \\"offset\\", \\"an integer\\", value);
+      }
+      if (length < 0) {
+        throw new errors.ERR_BUFFER_OUT_OF_BOUNDS();
+      }
+      throw new errors.ERR_OUT_OF_RANGE(type || \\"offset\\", \`>= \${type ? 1 : 0} and <= \${length}\`, value);
+    }
+    const INVALID_BASE64_RE = /[^+/0-9A-Za-z-_]/g;
+    function base64clean(str) {
+      str = str.split(\\"=\\")[0];
+      str = str.trim().replace(INVALID_BASE64_RE, \\"\\");
+      if (str.length < 2)
+        return \\"\\";
+      while (str.length % 4 !== 0) {
+        str = str + \\"=\\";
+      }
+      return str;
+    }
+    function utf8ToBytes(string, units) {
+      units = units || Infinity;
+      let codePoint;
+      const length = string.length;
+      let leadSurrogate = null;
+      const bytes = [];
+      for (let i = 0; i < length; ++i) {
+        codePoint = string.charCodeAt(i);
+        if (codePoint > 55295 && codePoint < 57344) {
+          if (!leadSurrogate) {
+            if (codePoint > 56319) {
+              if ((units -= 3) > -1)
+                bytes.push(239, 191, 189);
+              continue;
+            } else if (i + 1 === length) {
+              if ((units -= 3) > -1)
+                bytes.push(239, 191, 189);
+              continue;
+            }
+            leadSurrogate = codePoint;
+            continue;
+          }
+          if (codePoint < 56320) {
+            if ((units -= 3) > -1)
+              bytes.push(239, 191, 189);
+            leadSurrogate = codePoint;
+            continue;
+          }
+          codePoint = (leadSurrogate - 55296 << 10 | codePoint - 56320) + 65536;
+        } else if (leadSurrogate) {
+          if ((units -= 3) > -1)
+            bytes.push(239, 191, 189);
+        }
+        leadSurrogate = null;
+        if (codePoint < 128) {
+          if ((units -= 1) < 0)
+            break;
+          bytes.push(codePoint);
+        } else if (codePoint < 2048) {
+          if ((units -= 2) < 0)
+            break;
+          bytes.push(codePoint >> 6 | 192, codePoint & 63 | 128);
+        } else if (codePoint < 65536) {
+          if ((units -= 3) < 0)
+            break;
+          bytes.push(codePoint >> 12 | 224, codePoint >> 6 & 63 | 128, codePoint & 63 | 128);
+        } else if (codePoint < 1114112) {
+          if ((units -= 4) < 0)
+            break;
+          bytes.push(codePoint >> 18 | 240, codePoint >> 12 & 63 | 128, codePoint >> 6 & 63 | 128, codePoint & 63 | 128);
+        } else {
+          throw new Error(\\"Invalid code point\\");
+        }
+      }
+      return bytes;
+    }
+    function asciiToBytes(str) {
+      const byteArray = [];
+      for (let i = 0; i < str.length; ++i) {
+        byteArray.push(str.charCodeAt(i) & 255);
+      }
+      return byteArray;
+    }
+    function utf16leToBytes(str, units) {
+      let c, hi, lo;
+      const byteArray = [];
+      for (let i = 0; i < str.length; ++i) {
+        if ((units -= 2) < 0)
+          break;
+        c = str.charCodeAt(i);
+        hi = c >> 8;
+        lo = c % 256;
+        byteArray.push(lo);
+        byteArray.push(hi);
+      }
+      return byteArray;
+    }
+    function base64ToBytes(str) {
+      return base64.toByteArray(base64clean(str));
+    }
+    function blitBuffer(src, dst, offset, length) {
+      let i;
+      for (i = 0; i < length; ++i) {
+        if (i + offset >= dst.length || i >= src.length)
+          break;
+        dst[i + offset] = src[i];
+      }
+      return i;
+    }
+    function isInstance(obj, type) {
+      return obj instanceof type || obj != null && obj.constructor != null && obj.constructor.name != null && obj.constructor.name === type.name;
+    }
+    function numberIsNaN(obj) {
+      return obj !== obj;
+    }
+    const hexSliceLookupTable = function() {
+      const alphabet = \\"0123456789abcdef\\";
+      const table = new Array(256);
+      for (let i = 0; i < 16; ++i) {
+        const i16 = i * 16;
+        for (let j = 0; j < 16; ++j) {
+          table[i16 + j] = alphabet[i] + alphabet[j];
+        }
+      }
+      return table;
+    }();
+    function defineBigIntMethod(fn) {
+      return typeof BigInt === \\"undefined\\" ? BufferBigIntNotDefined : fn;
+    }
+    function BufferBigIntNotDefined() {
+      throw new Error(\\"BigInt not supported\\");
+    }
+    return exports$1;
+  }
+  var exports = dew();
+  exports[\\"Buffer\\"];
+  exports[\\"SlowBuffer\\"];
+  exports[\\"INSPECT_MAX_BYTES\\"];
+  exports[\\"kMaxLength\\"];
+  var Buffer = exports.Buffer;
+  var INSPECT_MAX_BYTES = exports.INSPECT_MAX_BYTES;
+  var kMaxLength = exports.kMaxLength;
+
+  // tests/fixtures/input/globalBuffer.ts
+  console.log(Buffer.from(\\"Hello world\\"));
+})();
+/*! Bundled license information:
+
+@jspm/core/nodelibs/browser/buffer.js:
+  (*! ieee754. BSD-3-Clause License. Feross Aboukhadijeh <https://feross.org/opensource> *)
+*/
+"
+`;
+
+exports[`Global Buffer Test > GIVEN a file that references the "Buffer" global when the polyfill is disabled THEN ignore polyfill 1`] = `
+"\\"use strict\\";
+(() => {
+  // tests/fixtures/input/globalBuffer.ts
+  console.log(Buffer.from(\\"Hello world\\"));
+})();
+"
+`;

--- a/tests/scenarios/__snapshots__/globalProcess.test.ts.snap
+++ b/tests/scenarios/__snapshots__/globalProcess.test.ts.snap
@@ -1,0 +1,305 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Global Process Test > GIVEN a file that references the "process" global THEN polyfill it 1`] = `
+"\\"use strict\\";
+(() => {
+  // node-modules-polyfills:node:process
+  function unimplemented(name) {
+    throw new Error(\\"Node.js process \\" + name + \\" is not supported by JSPM core outside of Node.js\\");
+  }
+  var queue = [];
+  var draining = false;
+  var currentQueue;
+  var queueIndex = -1;
+  function cleanUpNextTick() {
+    if (!draining || !currentQueue)
+      return;
+    draining = false;
+    if (currentQueue.length) {
+      queue = currentQueue.concat(queue);
+    } else {
+      queueIndex = -1;
+    }
+    if (queue.length)
+      drainQueue();
+  }
+  function drainQueue() {
+    if (draining)
+      return;
+    var timeout = setTimeout(cleanUpNextTick, 0);
+    draining = true;
+    var len = queue.length;
+    while (len) {
+      currentQueue = queue;
+      queue = [];
+      while (++queueIndex < len) {
+        if (currentQueue)
+          currentQueue[queueIndex].run();
+      }
+      queueIndex = -1;
+      len = queue.length;
+    }
+    currentQueue = null;
+    draining = false;
+    clearTimeout(timeout);
+  }
+  function nextTick(fun) {
+    var args = new Array(arguments.length - 1);
+    if (arguments.length > 1) {
+      for (var i = 1; i < arguments.length; i++)
+        args[i - 1] = arguments[i];
+    }
+    queue.push(new Item(fun, args));
+    if (queue.length === 1 && !draining)
+      setTimeout(drainQueue, 0);
+  }
+  function Item(fun, array) {
+    this.fun = fun;
+    this.array = array;
+  }
+  Item.prototype.run = function() {
+    this.fun.apply(null, this.array);
+  };
+  var title = \\"browser\\";
+  var arch = \\"x64\\";
+  var platform = \\"browser\\";
+  var env = {
+    PATH: \\"/usr/bin\\",
+    LANG: navigator.language + \\".UTF-8\\",
+    PWD: \\"/\\",
+    HOME: \\"/home\\",
+    TMP: \\"/tmp\\"
+  };
+  var argv = [\\"/usr/bin/node\\"];
+  var execArgv = [];
+  var version = \\"v16.8.0\\";
+  var versions = {};
+  var emitWarning = function(message, type) {
+    console.warn((type ? type + \\": \\" : \\"\\") + message);
+  };
+  var binding = function(name) {
+    unimplemented(\\"binding\\");
+  };
+  var umask = function(mask) {
+    return 0;
+  };
+  var cwd = function() {
+    return \\"/\\";
+  };
+  var chdir = function(dir) {
+  };
+  var release = {
+    name: \\"node\\",
+    sourceUrl: \\"\\",
+    headersUrl: \\"\\",
+    libUrl: \\"\\"
+  };
+  function noop() {
+  }
+  var _rawDebug = noop;
+  var moduleLoadList = [];
+  function _linkedBinding(name) {
+    unimplemented(\\"_linkedBinding\\");
+  }
+  var domain = {};
+  var _exiting = false;
+  var config = {};
+  function dlopen(name) {
+    unimplemented(\\"dlopen\\");
+  }
+  function _getActiveRequests() {
+    return [];
+  }
+  function _getActiveHandles() {
+    return [];
+  }
+  var reallyExit = noop;
+  var _kill = noop;
+  var cpuUsage = function() {
+    return {};
+  };
+  var resourceUsage = cpuUsage;
+  var memoryUsage = cpuUsage;
+  var kill = noop;
+  var exit = noop;
+  var openStdin = noop;
+  var allowedNodeEnvironmentFlags = {};
+  function assert(condition, message) {
+    if (!condition)
+      throw new Error(message || \\"assertion error\\");
+  }
+  var features = {
+    inspector: false,
+    debug: false,
+    uv: false,
+    ipv6: false,
+    tls_alpn: false,
+    tls_sni: false,
+    tls_ocsp: false,
+    tls: false,
+    cached_builtins: true
+  };
+  var _fatalExceptions = noop;
+  var setUncaughtExceptionCaptureCallback = noop;
+  function hasUncaughtExceptionCaptureCallback() {
+    return false;
+  }
+  var _tickCallback = noop;
+  var _debugProcess = noop;
+  var _debugEnd = noop;
+  var _startProfilerIdleNotifier = noop;
+  var _stopProfilerIdleNotifier = noop;
+  var stdout = void 0;
+  var stderr = void 0;
+  var stdin = void 0;
+  var abort = noop;
+  var pid = 2;
+  var ppid = 1;
+  var execPath = \\"/bin/usr/node\\";
+  var debugPort = 9229;
+  var argv0 = \\"node\\";
+  var _preload_modules = [];
+  var setSourceMapsEnabled = noop;
+  var _performance = {
+    now: typeof performance !== \\"undefined\\" ? performance.now.bind(performance) : void 0,
+    timing: typeof performance !== \\"undefined\\" ? performance.timing : void 0
+  };
+  if (_performance.now === void 0) {
+    nowOffset = Date.now();
+    if (_performance.timing && _performance.timing.navigationStart) {
+      nowOffset = _performance.timing.navigationStart;
+    }
+    _performance.now = () => Date.now() - nowOffset;
+  }
+  var nowOffset;
+  function uptime() {
+    return _performance.now() / 1e3;
+  }
+  var nanoPerSec = 1e9;
+  function hrtime(previousTimestamp) {
+    var baseNow = Math.floor((Date.now() - _performance.now()) * 1e-3);
+    var clocktime = _performance.now() * 1e-3;
+    var seconds = Math.floor(clocktime) + baseNow;
+    var nanoseconds = Math.floor(clocktime % 1 * 1e9);
+    if (previousTimestamp) {
+      seconds = seconds - previousTimestamp[0];
+      nanoseconds = nanoseconds - previousTimestamp[1];
+      if (nanoseconds < 0) {
+        seconds--;
+        nanoseconds += nanoPerSec;
+      }
+    }
+    return [seconds, nanoseconds];
+  }
+  hrtime.bigint = function(time) {
+    var diff = hrtime(time);
+    if (typeof BigInt === \\"undefined\\") {
+      return diff[0] * nanoPerSec + diff[1];
+    }
+    return BigInt(diff[0] * nanoPerSec) + BigInt(diff[1]);
+  };
+  var _maxListeners = 10;
+  var _events = {};
+  var _eventsCount = 0;
+  function on() {
+    return process;
+  }
+  var addListener = on;
+  var once = on;
+  var off = on;
+  var removeListener = on;
+  var removeAllListeners = on;
+  var emit = noop;
+  var prependListener = on;
+  var prependOnceListener = on;
+  function listeners(name) {
+    return [];
+  }
+  var process = {
+    version,
+    versions,
+    arch,
+    platform,
+    release,
+    _rawDebug,
+    moduleLoadList,
+    binding,
+    _linkedBinding,
+    _events,
+    _eventsCount,
+    _maxListeners,
+    on,
+    addListener,
+    once,
+    off,
+    removeListener,
+    removeAllListeners,
+    emit,
+    prependListener,
+    prependOnceListener,
+    listeners,
+    domain,
+    _exiting,
+    config,
+    dlopen,
+    uptime,
+    _getActiveRequests,
+    _getActiveHandles,
+    reallyExit,
+    _kill,
+    cpuUsage,
+    resourceUsage,
+    memoryUsage,
+    kill,
+    exit,
+    openStdin,
+    allowedNodeEnvironmentFlags,
+    assert,
+    features,
+    _fatalExceptions,
+    setUncaughtExceptionCaptureCallback,
+    hasUncaughtExceptionCaptureCallback,
+    emitWarning,
+    nextTick,
+    _tickCallback,
+    _debugProcess,
+    _debugEnd,
+    _startProfilerIdleNotifier,
+    _stopProfilerIdleNotifier,
+    stdout,
+    stdin,
+    stderr,
+    abort,
+    umask,
+    chdir,
+    cwd,
+    env,
+    title,
+    argv,
+    execArgv,
+    pid,
+    ppid,
+    execPath,
+    debugPort,
+    hrtime,
+    argv0,
+    _preload_modules,
+    setSourceMapsEnabled
+  };
+
+  // tests/fixtures/input/globalProcess.ts
+  console.log(process.version);
+  console.log(\\"production\\");
+})();
+"
+`;
+
+exports[`Global Process Test > GIVEN a file that references the "process" global when the polyfill is disabled THEN ignore polyfill 1`] = `
+"\\"use strict\\";
+(() => {
+  // tests/fixtures/input/globalProcess.ts
+  console.log(process.version);
+  console.log(\\"production\\");
+})();
+"
+`;

--- a/tests/scenarios/globalBuffer.test.ts
+++ b/tests/scenarios/globalBuffer.test.ts
@@ -1,0 +1,29 @@
+import esbuild, { type BuildOptions } from 'esbuild';
+
+import { assertFileContent, buildAbsolutePath, createEsbuildConfig } from '../util';
+
+import type { NodePolyfillsOptions } from '../../dist';
+
+function createConfig(pluginOptions?: NodePolyfillsOptions): BuildOptions {
+	return createEsbuildConfig(
+		{
+			format: 'iife',
+			entryPoints: [buildAbsolutePath('./fixtures/input/globalBuffer.ts')],
+		},
+		pluginOptions,
+	);
+}
+
+describe('Global Buffer Test', () => {
+	test('GIVEN a file that references the "Buffer" global THEN polyfill it', async () => {
+		const config = createConfig({ globals: { Buffer: true } });
+		await esbuild.build(config);
+		await assertFileContent('./fixtures/output/globalBuffer.js');
+	});
+
+	test('GIVEN a file that references the "Buffer" global when the polyfill is disabled THEN ignore polyfill', async () => {
+		const config = createConfig({ globals: { Buffer: false } });
+		await esbuild.build(config);
+		await assertFileContent('./fixtures/output/globalBuffer.js');
+	});
+});

--- a/tests/scenarios/globalProcess.test.ts
+++ b/tests/scenarios/globalProcess.test.ts
@@ -1,0 +1,32 @@
+import esbuild, { type BuildOptions } from 'esbuild';
+
+import { assertFileContent, buildAbsolutePath, createEsbuildConfig } from '../util';
+
+import type { NodePolyfillsOptions } from '../../dist';
+
+function createConfig(pluginOptions?: NodePolyfillsOptions): BuildOptions {
+	return createEsbuildConfig(
+		{
+			format: 'iife',
+			entryPoints: [buildAbsolutePath('./fixtures/input/globalProcess.ts')],
+
+			// Ensure that environment variables can still be injected via `define`
+			define: { 'process.env.NODE_ENV': '"production"' },
+		},
+		pluginOptions,
+	);
+}
+
+describe('Global Process Test', () => {
+	test('GIVEN a file that references the "process" global THEN polyfill it', async () => {
+		const config = createConfig({ globals: { process: true } });
+		await esbuild.build(config);
+		await assertFileContent('./fixtures/output/globalProcess.js');
+	});
+
+	test('GIVEN a file that references the "process" global when the polyfill is disabled THEN ignore polyfill', async () => {
+		const config = createConfig({ globals: { process: false } });
+		await esbuild.build(config);
+		await assertFileContent('./fixtures/output/globalProcess.js');
+	});
+});

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -5,5 +5,5 @@
 		"noEmit": true,
 		"incremental": false
 	},
-	"include": ["src", "tests", "tsup.config.ts", "vitest.config.ts"]
+	"include": ["src", "globals", "tests", "tsup.config.ts", "vitest.config.ts"]
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'tsup';
 export default defineConfig({
 	clean: true,
 	dts: true,
+	shims: true,
 	entry: ['src/index.ts'],
 	format: ['esm', 'cjs'],
 	minify: false,


### PR DESCRIPTION
This is a new feature based on an issue reported against Remix: https://github.com/remix-run/remix/issues/6665

In the linked issue (once the fix in #120 has been applied) the build fails due to a package that assumes the `process` global is available.

To address this scenario, this PR adds a new `globals` option to the plugin. In order to make this a non-breaking change, right now it's optional and disabled by default.

I realise there's a few details in this PR that you might want to change, particularly around the API and its surface area, but I thought this would be a good way to start the conversation at least.

**Status and versioning classification:**
- Code changes have been tested and working fine, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
