### PR TITLE
feat: add `modules` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ build({
 });
 ```
 
+Optionally configure which modules to polyfill:
+
+```ts
+import { nodeModulesPolyfillPlugin } from 'esbuild-plugins-node-modules-polyfill';
+import { build } from 'esbuild';
+build({
+	plugins: [nodeModulesPolyfillPlugin({
+		modules: ['crypto'],
+	})],
+});
+```
+
 Optionally inject globals when detected:
 
 ```ts

--- a/tests/scenarios/__snapshots__/polyfill.test.ts.snap
+++ b/tests/scenarios/__snapshots__/polyfill.test.ts.snap
@@ -672,3 +672,698 @@ exports[`Polyfill Test > GIVEN a file that imports a node builtin THEN polyfill 
 })();
 "
 `;
+
+exports[`Polyfill Test > GIVEN a file that imports a node builtin and doesn't opt into polyfill THEN don't polyfill it 1`] = `
+"\\"use strict\\";
+(() => {
+  var __require = /* @__PURE__ */ ((x) => typeof require !== \\"undefined\\" ? require : typeof Proxy !== \\"undefined\\" ? new Proxy(x, {
+    get: (a, b) => (typeof require !== \\"undefined\\" ? require : a)[b]
+  }) : x)(function(x) {
+    if (typeof require !== \\"undefined\\")
+      return require.apply(this, arguments);
+    throw Error('Dynamic require of \\"' + x + '\\" is not supported');
+  });
+
+  // tests/fixtures/input/polyfill.ts
+  var import_util = __require(\\"util\\");
+  var data = {
+    name: \\"esbuild\\"
+  };
+  var result = (0, import_util.inspect)(data, { depth: 0, colors: true });
+  console.log(result);
+})();
+"
+`;
+
+exports[`Polyfill Test > GIVEN a file that imports a node builtin and opts into polyfill THEN polyfill it 1`] = `
+"\\"use strict\\";
+(() => {
+  // node-modules-polyfills:util
+  var e;
+  var t;
+  var n;
+  var r = \\"undefined\\" != typeof globalThis ? globalThis : \\"undefined\\" != typeof self ? self : globalThis;
+  var o = e = {};
+  function i() {
+    throw new Error(\\"setTimeout has not been defined\\");
+  }
+  function u() {
+    throw new Error(\\"clearTimeout has not been defined\\");
+  }
+  function c(e3) {
+    if (t === setTimeout)
+      return setTimeout(e3, 0);
+    if ((t === i || !t) && setTimeout)
+      return t = setTimeout, setTimeout(e3, 0);
+    try {
+      return t(e3, 0);
+    } catch (n3) {
+      try {
+        return t.call(null, e3, 0);
+      } catch (n4) {
+        return t.call(this || r, e3, 0);
+      }
+    }
+  }
+  !function() {
+    try {
+      t = \\"function\\" == typeof setTimeout ? setTimeout : i;
+    } catch (e3) {
+      t = i;
+    }
+    try {
+      n = \\"function\\" == typeof clearTimeout ? clearTimeout : u;
+    } catch (e3) {
+      n = u;
+    }
+  }();
+  var l;
+  var s = [];
+  var f = false;
+  var a = -1;
+  function h() {
+    f && l && (f = false, l.length ? s = l.concat(s) : a = -1, s.length && d());
+  }
+  function d() {
+    if (!f) {
+      var e3 = c(h);
+      f = true;
+      for (var t3 = s.length; t3; ) {
+        for (l = s, s = []; ++a < t3; )
+          l && l[a].run();
+        a = -1, t3 = s.length;
+      }
+      l = null, f = false, function(e4) {
+        if (n === clearTimeout)
+          return clearTimeout(e4);
+        if ((n === u || !n) && clearTimeout)
+          return n = clearTimeout, clearTimeout(e4);
+        try {
+          n(e4);
+        } catch (t4) {
+          try {
+            return n.call(null, e4);
+          } catch (t5) {
+            return n.call(this || r, e4);
+          }
+        }
+      }(e3);
+    }
+  }
+  function m(e3, t3) {
+    (this || r).fun = e3, (this || r).array = t3;
+  }
+  function p() {
+  }
+  o.nextTick = function(e3) {
+    var t3 = new Array(arguments.length - 1);
+    if (arguments.length > 1)
+      for (var n3 = 1; n3 < arguments.length; n3++)
+        t3[n3 - 1] = arguments[n3];
+    s.push(new m(e3, t3)), 1 !== s.length || f || c(d);
+  }, m.prototype.run = function() {
+    (this || r).fun.apply(null, (this || r).array);
+  }, o.title = \\"browser\\", o.browser = true, o.env = {}, o.argv = [], o.version = \\"\\", o.versions = {}, o.on = p, o.addListener = p, o.once = p, o.off = p, o.removeListener = p, o.removeAllListeners = p, o.emit = p, o.prependListener = p, o.prependOnceListener = p, o.listeners = function(e3) {
+    return [];
+  }, o.binding = function(e3) {
+    throw new Error(\\"process.binding is not supported\\");
+  }, o.cwd = function() {
+    return \\"/\\";
+  }, o.chdir = function(e3) {
+    throw new Error(\\"process.chdir is not supported\\");
+  }, o.umask = function() {
+    return 0;
+  };
+  var T = e;
+  T.addListener;
+  T.argv;
+  T.binding;
+  T.browser;
+  T.chdir;
+  T.cwd;
+  T.emit;
+  T.env;
+  T.listeners;
+  T.nextTick;
+  T.off;
+  T.on;
+  T.once;
+  T.prependListener;
+  T.prependOnceListener;
+  T.removeAllListeners;
+  T.removeListener;
+  T.title;
+  T.umask;
+  T.version;
+  T.versions;
+  var t2 = \\"function\\" == typeof Symbol && \\"symbol\\" == typeof Symbol.toStringTag;
+  var e2 = Object.prototype.toString;
+  var o2 = function(o3) {
+    return !(t2 && o3 && \\"object\\" == typeof o3 && Symbol.toStringTag in o3) && \\"[object Arguments]\\" === e2.call(o3);
+  };
+  var n2 = function(t3) {
+    return !!o2(t3) || null !== t3 && \\"object\\" == typeof t3 && \\"number\\" == typeof t3.length && t3.length >= 0 && \\"[object Array]\\" !== e2.call(t3) && \\"[object Function]\\" === e2.call(t3.callee);
+  };
+  var r2 = function() {
+    return o2(arguments);
+  }();
+  o2.isLegacyArguments = n2;
+  var l2 = r2 ? o2 : n2;
+  var t$1 = Object.prototype.toString;
+  var o$1 = Function.prototype.toString;
+  var n$1 = /^\\\\s*(?:function)?\\\\*/;
+  var e$1 = \\"function\\" == typeof Symbol && \\"symbol\\" == typeof Symbol.toStringTag;
+  var r$1 = Object.getPrototypeOf;
+  var c2 = function() {
+    if (!e$1)
+      return false;
+    try {
+      return Function(\\"return function*() {}\\")();
+    } catch (t3) {
+    }
+  }();
+  var u2 = c2 ? r$1(c2) : {};
+  var i2 = function(c3) {
+    return \\"function\\" == typeof c3 && (!!n$1.test(o$1.call(c3)) || (e$1 ? r$1(c3) === u2 : \\"[object GeneratorFunction]\\" === t$1.call(c3)));
+  };
+  var t$2 = \\"function\\" == typeof Object.create ? function(t3, e3) {
+    e3 && (t3.super_ = e3, t3.prototype = Object.create(e3.prototype, { constructor: { value: t3, enumerable: false, writable: true, configurable: true } }));
+  } : function(t3, e3) {
+    if (e3) {
+      t3.super_ = e3;
+      var o3 = function() {
+      };
+      o3.prototype = e3.prototype, t3.prototype = new o3(), t3.prototype.constructor = t3;
+    }
+  };
+  var i$1 = function(e3) {
+    return e3 && \\"object\\" == typeof e3 && \\"function\\" == typeof e3.copy && \\"function\\" == typeof e3.fill && \\"function\\" == typeof e3.readUInt8;
+  };
+  var o$2 = {};
+  var u$1 = i$1;
+  var f2 = l2;
+  var a2 = i2;
+  function c$1(e3) {
+    return e3.call.bind(e3);
+  }
+  var s2 = \\"undefined\\" != typeof BigInt;
+  var p2 = \\"undefined\\" != typeof Symbol;
+  var y = p2 && void 0 !== Symbol.toStringTag;
+  var l$1 = \\"undefined\\" != typeof Uint8Array;
+  var d2 = \\"undefined\\" != typeof ArrayBuffer;
+  if (l$1 && y)
+    var g = Object.getPrototypeOf(Uint8Array.prototype), b = c$1(Object.getOwnPropertyDescriptor(g, Symbol.toStringTag).get);
+  var m2 = c$1(Object.prototype.toString);
+  var h2 = c$1(Number.prototype.valueOf);
+  var j = c$1(String.prototype.valueOf);
+  var A = c$1(Boolean.prototype.valueOf);
+  if (s2)
+    var w = c$1(BigInt.prototype.valueOf);
+  if (p2)
+    var v = c$1(Symbol.prototype.valueOf);
+  function O(e3, t3) {
+    if (\\"object\\" != typeof e3)
+      return false;
+    try {
+      return t3(e3), true;
+    } catch (e4) {
+      return false;
+    }
+  }
+  function S(e3) {
+    return l$1 && y ? void 0 !== b(e3) : B(e3) || k(e3) || E(e3) || D(e3) || U(e3) || P(e3) || x(e3) || I(e3) || M(e3) || z(e3) || F(e3);
+  }
+  function B(e3) {
+    return l$1 && y ? \\"Uint8Array\\" === b(e3) : \\"[object Uint8Array]\\" === m2(e3) || u$1(e3) && void 0 !== e3.buffer;
+  }
+  function k(e3) {
+    return l$1 && y ? \\"Uint8ClampedArray\\" === b(e3) : \\"[object Uint8ClampedArray]\\" === m2(e3);
+  }
+  function E(e3) {
+    return l$1 && y ? \\"Uint16Array\\" === b(e3) : \\"[object Uint16Array]\\" === m2(e3);
+  }
+  function D(e3) {
+    return l$1 && y ? \\"Uint32Array\\" === b(e3) : \\"[object Uint32Array]\\" === m2(e3);
+  }
+  function U(e3) {
+    return l$1 && y ? \\"Int8Array\\" === b(e3) : \\"[object Int8Array]\\" === m2(e3);
+  }
+  function P(e3) {
+    return l$1 && y ? \\"Int16Array\\" === b(e3) : \\"[object Int16Array]\\" === m2(e3);
+  }
+  function x(e3) {
+    return l$1 && y ? \\"Int32Array\\" === b(e3) : \\"[object Int32Array]\\" === m2(e3);
+  }
+  function I(e3) {
+    return l$1 && y ? \\"Float32Array\\" === b(e3) : \\"[object Float32Array]\\" === m2(e3);
+  }
+  function M(e3) {
+    return l$1 && y ? \\"Float64Array\\" === b(e3) : \\"[object Float64Array]\\" === m2(e3);
+  }
+  function z(e3) {
+    return l$1 && y ? \\"BigInt64Array\\" === b(e3) : \\"[object BigInt64Array]\\" === m2(e3);
+  }
+  function F(e3) {
+    return l$1 && y ? \\"BigUint64Array\\" === b(e3) : \\"[object BigUint64Array]\\" === m2(e3);
+  }
+  function T2(e3) {
+    return \\"[object Map]\\" === m2(e3);
+  }
+  function N(e3) {
+    return \\"[object Set]\\" === m2(e3);
+  }
+  function W(e3) {
+    return \\"[object WeakMap]\\" === m2(e3);
+  }
+  function $(e3) {
+    return \\"[object WeakSet]\\" === m2(e3);
+  }
+  function C(e3) {
+    return \\"[object ArrayBuffer]\\" === m2(e3);
+  }
+  function V(e3) {
+    return \\"undefined\\" != typeof ArrayBuffer && (C.working ? C(e3) : e3 instanceof ArrayBuffer);
+  }
+  function G(e3) {
+    return \\"[object DataView]\\" === m2(e3);
+  }
+  function R(e3) {
+    return \\"undefined\\" != typeof DataView && (G.working ? G(e3) : e3 instanceof DataView);
+  }
+  function J(e3) {
+    return \\"[object SharedArrayBuffer]\\" === m2(e3);
+  }
+  function _(e3) {
+    return \\"undefined\\" != typeof SharedArrayBuffer && (J.working ? J(e3) : e3 instanceof SharedArrayBuffer);
+  }
+  function H(e3) {
+    return O(e3, h2);
+  }
+  function Z(e3) {
+    return O(e3, j);
+  }
+  function q(e3) {
+    return O(e3, A);
+  }
+  function K(e3) {
+    return s2 && O(e3, w);
+  }
+  function L(e3) {
+    return p2 && O(e3, v);
+  }
+  o$2.isArgumentsObject = f2, o$2.isGeneratorFunction = a2, o$2.isPromise = function(e3) {
+    return \\"undefined\\" != typeof Promise && e3 instanceof Promise || null !== e3 && \\"object\\" == typeof e3 && \\"function\\" == typeof e3.then && \\"function\\" == typeof e3.catch;
+  }, o$2.isArrayBufferView = function(e3) {
+    return d2 && ArrayBuffer.isView ? ArrayBuffer.isView(e3) : S(e3) || R(e3);
+  }, o$2.isTypedArray = S, o$2.isUint8Array = B, o$2.isUint8ClampedArray = k, o$2.isUint16Array = E, o$2.isUint32Array = D, o$2.isInt8Array = U, o$2.isInt16Array = P, o$2.isInt32Array = x, o$2.isFloat32Array = I, o$2.isFloat64Array = M, o$2.isBigInt64Array = z, o$2.isBigUint64Array = F, T2.working = \\"undefined\\" != typeof Map && T2(/* @__PURE__ */ new Map()), o$2.isMap = function(e3) {
+    return \\"undefined\\" != typeof Map && (T2.working ? T2(e3) : e3 instanceof Map);
+  }, N.working = \\"undefined\\" != typeof Set && N(/* @__PURE__ */ new Set()), o$2.isSet = function(e3) {
+    return \\"undefined\\" != typeof Set && (N.working ? N(e3) : e3 instanceof Set);
+  }, W.working = \\"undefined\\" != typeof WeakMap && W(/* @__PURE__ */ new WeakMap()), o$2.isWeakMap = function(e3) {
+    return \\"undefined\\" != typeof WeakMap && (W.working ? W(e3) : e3 instanceof WeakMap);
+  }, $.working = \\"undefined\\" != typeof WeakSet && $(/* @__PURE__ */ new WeakSet()), o$2.isWeakSet = function(e3) {
+    return $(e3);
+  }, C.working = \\"undefined\\" != typeof ArrayBuffer && C(new ArrayBuffer()), o$2.isArrayBuffer = V, G.working = \\"undefined\\" != typeof ArrayBuffer && \\"undefined\\" != typeof DataView && G(new DataView(new ArrayBuffer(1), 0, 1)), o$2.isDataView = R, J.working = \\"undefined\\" != typeof SharedArrayBuffer && J(new SharedArrayBuffer()), o$2.isSharedArrayBuffer = _, o$2.isAsyncFunction = function(e3) {
+    return \\"[object AsyncFunction]\\" === m2(e3);
+  }, o$2.isMapIterator = function(e3) {
+    return \\"[object Map Iterator]\\" === m2(e3);
+  }, o$2.isSetIterator = function(e3) {
+    return \\"[object Set Iterator]\\" === m2(e3);
+  }, o$2.isGeneratorObject = function(e3) {
+    return \\"[object Generator]\\" === m2(e3);
+  }, o$2.isWebAssemblyCompiledModule = function(e3) {
+    return \\"[object WebAssembly.Module]\\" === m2(e3);
+  }, o$2.isNumberObject = H, o$2.isStringObject = Z, o$2.isBooleanObject = q, o$2.isBigIntObject = K, o$2.isSymbolObject = L, o$2.isBoxedPrimitive = function(e3) {
+    return H(e3) || Z(e3) || q(e3) || K(e3) || L(e3);
+  }, o$2.isAnyArrayBuffer = function(e3) {
+    return l$1 && (V(e3) || _(e3));
+  }, [\\"isProxy\\", \\"isExternal\\", \\"isModuleNamespaceObject\\"].forEach(function(e3) {
+    Object.defineProperty(o$2, e3, { enumerable: false, value: function() {
+      throw new Error(e3 + \\" is not supported in userland\\");
+    } });
+  });
+  var Q = \\"undefined\\" != typeof globalThis ? globalThis : \\"undefined\\" != typeof self ? self : globalThis;
+  var X = {};
+  var Y = T;
+  var ee = Object.getOwnPropertyDescriptors || function(e3) {
+    for (var t3 = Object.keys(e3), r3 = {}, n3 = 0; n3 < t3.length; n3++)
+      r3[t3[n3]] = Object.getOwnPropertyDescriptor(e3, t3[n3]);
+    return r3;
+  };
+  var te = /%[sdj%]/g;
+  X.format = function(e3) {
+    if (!ge(e3)) {
+      for (var t3 = [], r3 = 0; r3 < arguments.length; r3++)
+        t3.push(oe(arguments[r3]));
+      return t3.join(\\" \\");
+    }
+    r3 = 1;
+    for (var n3 = arguments, i3 = n3.length, o3 = String(e3).replace(te, function(e4) {
+      if (\\"%%\\" === e4)
+        return \\"%\\";
+      if (r3 >= i3)
+        return e4;
+      switch (e4) {
+        case \\"%s\\":
+          return String(n3[r3++]);
+        case \\"%d\\":
+          return Number(n3[r3++]);
+        case \\"%j\\":
+          try {
+            return JSON.stringify(n3[r3++]);
+          } catch (e5) {
+            return \\"[Circular]\\";
+          }
+        default:
+          return e4;
+      }
+    }), u3 = n3[r3]; r3 < i3; u3 = n3[++r3])
+      le(u3) || !he(u3) ? o3 += \\" \\" + u3 : o3 += \\" \\" + oe(u3);
+    return o3;
+  }, X.deprecate = function(e3, t3) {
+    if (void 0 !== Y && true === Y.noDeprecation)
+      return e3;
+    if (void 0 === Y)
+      return function() {
+        return X.deprecate(e3, t3).apply(this || Q, arguments);
+      };
+    var r3 = false;
+    return function() {
+      if (!r3) {
+        if (Y.throwDeprecation)
+          throw new Error(t3);
+        Y.traceDeprecation ? console.trace(t3) : console.error(t3), r3 = true;
+      }
+      return e3.apply(this || Q, arguments);
+    };
+  };
+  var re = {};
+  var ne = /^$/;
+  if (Y.env.NODE_DEBUG) {
+    ie = Y.env.NODE_DEBUG;
+    ie = ie.replace(/[|\\\\\\\\{}()[\\\\]^$+?.]/g, \\"\\\\\\\\$&\\").replace(/\\\\*/g, \\".*\\").replace(/,/g, \\"$|^\\").toUpperCase(), ne = new RegExp(\\"^\\" + ie + \\"$\\", \\"i\\");
+  }
+  var ie;
+  function oe(e3, t3) {
+    var r3 = { seen: [], stylize: fe };
+    return arguments.length >= 3 && (r3.depth = arguments[2]), arguments.length >= 4 && (r3.colors = arguments[3]), ye(t3) ? r3.showHidden = t3 : t3 && X._extend(r3, t3), be(r3.showHidden) && (r3.showHidden = false), be(r3.depth) && (r3.depth = 2), be(r3.colors) && (r3.colors = false), be(r3.customInspect) && (r3.customInspect = true), r3.colors && (r3.stylize = ue), ae(r3, e3, r3.depth);
+  }
+  function ue(e3, t3) {
+    var r3 = oe.styles[t3];
+    return r3 ? \\"\\\\x1B[\\" + oe.colors[r3][0] + \\"m\\" + e3 + \\"\\\\x1B[\\" + oe.colors[r3][1] + \\"m\\" : e3;
+  }
+  function fe(e3, t3) {
+    return e3;
+  }
+  function ae(e3, t3, r3) {
+    if (e3.customInspect && t3 && we(t3.inspect) && t3.inspect !== X.inspect && (!t3.constructor || t3.constructor.prototype !== t3)) {
+      var n3 = t3.inspect(r3, e3);
+      return ge(n3) || (n3 = ae(e3, n3, r3)), n3;
+    }
+    var i3 = function(e4, t4) {
+      if (be(t4))
+        return e4.stylize(\\"undefined\\", \\"undefined\\");
+      if (ge(t4)) {
+        var r4 = \\"'\\" + JSON.stringify(t4).replace(/^\\"|\\"$/g, \\"\\").replace(/'/g, \\"\\\\\\\\'\\").replace(/\\\\\\\\\\"/g, '\\"') + \\"'\\";
+        return e4.stylize(r4, \\"string\\");
+      }
+      if (de(t4))
+        return e4.stylize(\\"\\" + t4, \\"number\\");
+      if (ye(t4))
+        return e4.stylize(\\"\\" + t4, \\"boolean\\");
+      if (le(t4))
+        return e4.stylize(\\"null\\", \\"null\\");
+    }(e3, t3);
+    if (i3)
+      return i3;
+    var o3 = Object.keys(t3), u3 = function(e4) {
+      var t4 = {};
+      return e4.forEach(function(e5, r4) {
+        t4[e5] = true;
+      }), t4;
+    }(o3);
+    if (e3.showHidden && (o3 = Object.getOwnPropertyNames(t3)), Ae(t3) && (o3.indexOf(\\"message\\") >= 0 || o3.indexOf(\\"description\\") >= 0))
+      return ce(t3);
+    if (0 === o3.length) {
+      if (we(t3)) {
+        var f3 = t3.name ? \\": \\" + t3.name : \\"\\";
+        return e3.stylize(\\"[Function\\" + f3 + \\"]\\", \\"special\\");
+      }
+      if (me(t3))
+        return e3.stylize(RegExp.prototype.toString.call(t3), \\"regexp\\");
+      if (je(t3))
+        return e3.stylize(Date.prototype.toString.call(t3), \\"date\\");
+      if (Ae(t3))
+        return ce(t3);
+    }
+    var a3, c3 = \\"\\", s3 = false, p3 = [\\"{\\", \\"}\\"];
+    (pe(t3) && (s3 = true, p3 = [\\"[\\", \\"]\\"]), we(t3)) && (c3 = \\" [Function\\" + (t3.name ? \\": \\" + t3.name : \\"\\") + \\"]\\");
+    return me(t3) && (c3 = \\" \\" + RegExp.prototype.toString.call(t3)), je(t3) && (c3 = \\" \\" + Date.prototype.toUTCString.call(t3)), Ae(t3) && (c3 = \\" \\" + ce(t3)), 0 !== o3.length || s3 && 0 != t3.length ? r3 < 0 ? me(t3) ? e3.stylize(RegExp.prototype.toString.call(t3), \\"regexp\\") : e3.stylize(\\"[Object]\\", \\"special\\") : (e3.seen.push(t3), a3 = s3 ? function(e4, t4, r4, n4, i4) {
+      for (var o4 = [], u4 = 0, f4 = t4.length; u4 < f4; ++u4)
+        ke(t4, String(u4)) ? o4.push(se(e4, t4, r4, n4, String(u4), true)) : o4.push(\\"\\");
+      return i4.forEach(function(i5) {
+        i5.match(/^\\\\d+$/) || o4.push(se(e4, t4, r4, n4, i5, true));
+      }), o4;
+    }(e3, t3, r3, u3, o3) : o3.map(function(n4) {
+      return se(e3, t3, r3, u3, n4, s3);
+    }), e3.seen.pop(), function(e4, t4, r4) {
+      var n4 = 0;
+      if (e4.reduce(function(e5, t5) {
+        return n4++, t5.indexOf(\\"\\\\n\\") >= 0 && n4++, e5 + t5.replace(/\\\\u001b\\\\[\\\\d\\\\d?m/g, \\"\\").length + 1;
+      }, 0) > 60)
+        return r4[0] + (\\"\\" === t4 ? \\"\\" : t4 + \\"\\\\n \\") + \\" \\" + e4.join(\\",\\\\n  \\") + \\" \\" + r4[1];
+      return r4[0] + t4 + \\" \\" + e4.join(\\", \\") + \\" \\" + r4[1];
+    }(a3, c3, p3)) : p3[0] + c3 + p3[1];
+  }
+  function ce(e3) {
+    return \\"[\\" + Error.prototype.toString.call(e3) + \\"]\\";
+  }
+  function se(e3, t3, r3, n3, i3, o3) {
+    var u3, f3, a3;
+    if ((a3 = Object.getOwnPropertyDescriptor(t3, i3) || { value: t3[i3] }).get ? f3 = a3.set ? e3.stylize(\\"[Getter/Setter]\\", \\"special\\") : e3.stylize(\\"[Getter]\\", \\"special\\") : a3.set && (f3 = e3.stylize(\\"[Setter]\\", \\"special\\")), ke(n3, i3) || (u3 = \\"[\\" + i3 + \\"]\\"), f3 || (e3.seen.indexOf(a3.value) < 0 ? (f3 = le(r3) ? ae(e3, a3.value, null) : ae(e3, a3.value, r3 - 1)).indexOf(\\"\\\\n\\") > -1 && (f3 = o3 ? f3.split(\\"\\\\n\\").map(function(e4) {
+      return \\"  \\" + e4;
+    }).join(\\"\\\\n\\").substr(2) : \\"\\\\n\\" + f3.split(\\"\\\\n\\").map(function(e4) {
+      return \\"   \\" + e4;
+    }).join(\\"\\\\n\\")) : f3 = e3.stylize(\\"[Circular]\\", \\"special\\")), be(u3)) {
+      if (o3 && i3.match(/^\\\\d+$/))
+        return f3;
+      (u3 = JSON.stringify(\\"\\" + i3)).match(/^\\"([a-zA-Z_][a-zA-Z_0-9]*)\\"$/) ? (u3 = u3.substr(1, u3.length - 2), u3 = e3.stylize(u3, \\"name\\")) : (u3 = u3.replace(/'/g, \\"\\\\\\\\'\\").replace(/\\\\\\\\\\"/g, '\\"').replace(/(^\\"|\\"$)/g, \\"'\\"), u3 = e3.stylize(u3, \\"string\\"));
+    }
+    return u3 + \\": \\" + f3;
+  }
+  function pe(e3) {
+    return Array.isArray(e3);
+  }
+  function ye(e3) {
+    return \\"boolean\\" == typeof e3;
+  }
+  function le(e3) {
+    return null === e3;
+  }
+  function de(e3) {
+    return \\"number\\" == typeof e3;
+  }
+  function ge(e3) {
+    return \\"string\\" == typeof e3;
+  }
+  function be(e3) {
+    return void 0 === e3;
+  }
+  function me(e3) {
+    return he(e3) && \\"[object RegExp]\\" === ve(e3);
+  }
+  function he(e3) {
+    return \\"object\\" == typeof e3 && null !== e3;
+  }
+  function je(e3) {
+    return he(e3) && \\"[object Date]\\" === ve(e3);
+  }
+  function Ae(e3) {
+    return he(e3) && (\\"[object Error]\\" === ve(e3) || e3 instanceof Error);
+  }
+  function we(e3) {
+    return \\"function\\" == typeof e3;
+  }
+  function ve(e3) {
+    return Object.prototype.toString.call(e3);
+  }
+  function Oe(e3) {
+    return e3 < 10 ? \\"0\\" + e3.toString(10) : e3.toString(10);
+  }
+  X.debuglog = function(e3) {
+    if (e3 = e3.toUpperCase(), !re[e3])
+      if (ne.test(e3)) {
+        var t3 = Y.pid;
+        re[e3] = function() {
+          var r3 = X.format.apply(X, arguments);
+          console.error(\\"%s %d: %s\\", e3, t3, r3);
+        };
+      } else
+        re[e3] = function() {
+        };
+    return re[e3];
+  }, X.inspect = oe, oe.colors = { bold: [1, 22], italic: [3, 23], underline: [4, 24], inverse: [7, 27], white: [37, 39], grey: [90, 39], black: [30, 39], blue: [34, 39], cyan: [36, 39], green: [32, 39], magenta: [35, 39], red: [31, 39], yellow: [33, 39] }, oe.styles = { special: \\"cyan\\", number: \\"yellow\\", boolean: \\"yellow\\", undefined: \\"grey\\", null: \\"bold\\", string: \\"green\\", date: \\"magenta\\", regexp: \\"red\\" }, X.types = o$2, X.isArray = pe, X.isBoolean = ye, X.isNull = le, X.isNullOrUndefined = function(e3) {
+    return null == e3;
+  }, X.isNumber = de, X.isString = ge, X.isSymbol = function(e3) {
+    return \\"symbol\\" == typeof e3;
+  }, X.isUndefined = be, X.isRegExp = me, X.types.isRegExp = me, X.isObject = he, X.isDate = je, X.types.isDate = je, X.isError = Ae, X.types.isNativeError = Ae, X.isFunction = we, X.isPrimitive = function(e3) {
+    return null === e3 || \\"boolean\\" == typeof e3 || \\"number\\" == typeof e3 || \\"string\\" == typeof e3 || \\"symbol\\" == typeof e3 || void 0 === e3;
+  }, X.isBuffer = i$1;
+  var Se = [\\"Jan\\", \\"Feb\\", \\"Mar\\", \\"Apr\\", \\"May\\", \\"Jun\\", \\"Jul\\", \\"Aug\\", \\"Sep\\", \\"Oct\\", \\"Nov\\", \\"Dec\\"];
+  function Be() {
+    var e3 = /* @__PURE__ */ new Date(), t3 = [Oe(e3.getHours()), Oe(e3.getMinutes()), Oe(e3.getSeconds())].join(\\":\\");
+    return [e3.getDate(), Se[e3.getMonth()], t3].join(\\" \\");
+  }
+  function ke(e3, t3) {
+    return Object.prototype.hasOwnProperty.call(e3, t3);
+  }
+  X.log = function() {
+    console.log(\\"%s - %s\\", Be(), X.format.apply(X, arguments));
+  }, X.inherits = t$2, X._extend = function(e3, t3) {
+    if (!t3 || !he(t3))
+      return e3;
+    for (var r3 = Object.keys(t3), n3 = r3.length; n3--; )
+      e3[r3[n3]] = t3[r3[n3]];
+    return e3;
+  };
+  var Ee = \\"undefined\\" != typeof Symbol ? Symbol(\\"util.promisify.custom\\") : void 0;
+  function De(e3, t3) {
+    if (!e3) {
+      var r3 = new Error(\\"Promise was rejected with a falsy value\\");
+      r3.reason = e3, e3 = r3;
+    }
+    return t3(e3);
+  }
+  X.promisify = function(e3) {
+    if (\\"function\\" != typeof e3)
+      throw new TypeError('The \\"original\\" argument must be of type Function');
+    if (Ee && e3[Ee]) {
+      var t3;
+      if (\\"function\\" != typeof (t3 = e3[Ee]))
+        throw new TypeError('The \\"util.promisify.custom\\" argument must be of type Function');
+      return Object.defineProperty(t3, Ee, { value: t3, enumerable: false, writable: false, configurable: true }), t3;
+    }
+    function t3() {
+      for (var t4, r3, n3 = new Promise(function(e4, n4) {
+        t4 = e4, r3 = n4;
+      }), i3 = [], o3 = 0; o3 < arguments.length; o3++)
+        i3.push(arguments[o3]);
+      i3.push(function(e4, n4) {
+        e4 ? r3(e4) : t4(n4);
+      });
+      try {
+        e3.apply(this || Q, i3);
+      } catch (e4) {
+        r3(e4);
+      }
+      return n3;
+    }
+    return Object.setPrototypeOf(t3, Object.getPrototypeOf(e3)), Ee && Object.defineProperty(t3, Ee, { value: t3, enumerable: false, writable: false, configurable: true }), Object.defineProperties(t3, ee(e3));
+  }, X.promisify.custom = Ee, X.callbackify = function(e3) {
+    if (\\"function\\" != typeof e3)
+      throw new TypeError('The \\"original\\" argument must be of type Function');
+    function t3() {
+      for (var t4 = [], r3 = 0; r3 < arguments.length; r3++)
+        t4.push(arguments[r3]);
+      var n3 = t4.pop();
+      if (\\"function\\" != typeof n3)
+        throw new TypeError(\\"The last argument must be of type Function\\");
+      var i3 = this || Q, o3 = function() {
+        return n3.apply(i3, arguments);
+      };
+      e3.apply(this || Q, t4).then(function(e4) {
+        Y.nextTick(o3.bind(null, null, e4));
+      }, function(e4) {
+        Y.nextTick(De.bind(null, e4, o3));
+      });
+    }
+    return Object.setPrototypeOf(t3, Object.getPrototypeOf(e3)), Object.defineProperties(t3, ee(e3)), t3;
+  };
+  X._extend;
+  X.callbackify;
+  X.debuglog;
+  X.deprecate;
+  X.format;
+  X.inherits;
+  X.inspect;
+  X.isArray;
+  X.isBoolean;
+  X.isBuffer;
+  X.isDate;
+  X.isError;
+  X.isFunction;
+  X.isNull;
+  X.isNullOrUndefined;
+  X.isNumber;
+  X.isObject;
+  X.isPrimitive;
+  X.isRegExp;
+  X.isString;
+  X.isSymbol;
+  X.isUndefined;
+  X.log;
+  X.promisify;
+  var _extend = X._extend;
+  var callbackify = X.callbackify;
+  var debuglog = X.debuglog;
+  var deprecate = X.deprecate;
+  var format = X.format;
+  var inherits = X.inherits;
+  var inspect = X.inspect;
+  var isArray = X.isArray;
+  var isBoolean = X.isBoolean;
+  var isBuffer = X.isBuffer;
+  var isDate = X.isDate;
+  var isError = X.isError;
+  var isFunction = X.isFunction;
+  var isNull = X.isNull;
+  var isNullOrUndefined = X.isNullOrUndefined;
+  var isNumber = X.isNumber;
+  var isObject = X.isObject;
+  var isPrimitive = X.isPrimitive;
+  var isRegExp = X.isRegExp;
+  var isString = X.isString;
+  var isSymbol = X.isSymbol;
+  var isUndefined = X.isUndefined;
+  var log = X.log;
+  var promisify = X.promisify;
+  var types = X.types;
+  var TextEncoder = self.TextEncoder;
+  var TextDecoder = self.TextDecoder;
+  var _extend2 = X._extend;
+  var callbackify2 = X.callbackify;
+  var debuglog2 = X.debuglog;
+  var deprecate2 = X.deprecate;
+  var format2 = X.format;
+  var inherits2 = X.inherits;
+  var inspect2 = X.inspect;
+  var isArray2 = X.isArray;
+  var isBoolean2 = X.isBoolean;
+  var isBuffer2 = X.isBuffer;
+  var isDate2 = X.isDate;
+  var isError2 = X.isError;
+  var isFunction2 = X.isFunction;
+  var isNull2 = X.isNull;
+  var isNullOrUndefined2 = X.isNullOrUndefined;
+  var isNumber2 = X.isNumber;
+  var isObject2 = X.isObject;
+  var isPrimitive2 = X.isPrimitive;
+  var isRegExp2 = X.isRegExp;
+  var isString2 = X.isString;
+  var isSymbol2 = X.isSymbol;
+  var isUndefined2 = X.isUndefined;
+  var log2 = X.log;
+  var promisify2 = X.promisify;
+  var types2 = X.types;
+  var TextEncoder2 = X.TextEncoder = globalThis.TextEncoder;
+  var TextDecoder2 = X.TextDecoder = globalThis.TextDecoder;
+
+  // tests/fixtures/input/polyfill.ts
+  var data = {
+    name: \\"esbuild\\"
+  };
+  var result = inspect2(data, { depth: 0, colors: true });
+  console.log(result);
+})();
+"
+`;

--- a/tests/scenarios/polyfill.test.ts
+++ b/tests/scenarios/polyfill.test.ts
@@ -22,4 +22,24 @@ describe('Polyfill Test', () => {
 
 		await assertFileContent('./fixtures/output/polyfill.js');
 	});
+
+	test('GIVEN a file that imports a node builtin and opts into polyfill THEN polyfill it', async () => {
+		const config = createConfig({
+			modules: ['util'],
+		});
+
+		await esbuild.build(config);
+
+		await assertFileContent('./fixtures/output/polyfill.js');
+	});
+
+	test("GIVEN a file that imports a node builtin and doesn't opt into polyfill THEN don't polyfill it", async () => {
+		const config = createConfig({
+			modules: [],
+		});
+
+		await esbuild.build(config);
+
+		await assertFileContent('./fixtures/output/polyfill.js');
+	});
 });


### PR DESCRIPTION
This option gives consumers the ability to opt into specific polyfills.

The need for this came up in the context of Remix (https://github.com/remix-run/remix/issues/6715) where some consumers are targeting [Cloudflare in `nodejs_compat` mode](https://developers.cloudflare.com/workers/platform/nodejs-compatibility) which provides its own polyfills. Notably, Cloudflare supports [Node's async_hooks API](https://nodejs.org/api/async_hooks.html) which actually throws an error if this plugin tries to polyfill it.

**Status and versioning classification:**
- Code changes have been tested and working fine, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
