### PR TITLE
feat: optionally provide empty polyfills

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,21 @@ build({
 });
 ```
 
+Optionally provide empty polyfills:
+
+```ts
+import { nodeModulesPolyfillPlugin } from 'esbuild-plugins-node-modules-polyfill';
+import { build } from 'esbuild';
+build({
+	plugins: [nodeModulesPolyfillPlugin({
+		modules: {
+			fs: 'empty',
+			crypto: true,
+		}
+	})],
+});
+```
+
 Optionally inject globals when detected:
 
 ```ts

--- a/tests/scenarios/__snapshots__/polyfill.test.ts.snap
+++ b/tests/scenarios/__snapshots__/polyfill.test.ts.snap
@@ -695,6 +695,75 @@ exports[`Polyfill Test > GIVEN a file that imports a node builtin and doesn't op
 "
 `;
 
+exports[`Polyfill Test > GIVEN a file that imports a node builtin and explicitly opts out of polyfill THEN don't polyfill it 1`] = `
+"\\"use strict\\";
+(() => {
+  var __require = /* @__PURE__ */ ((x) => typeof require !== \\"undefined\\" ? require : typeof Proxy !== \\"undefined\\" ? new Proxy(x, {
+    get: (a, b) => (typeof require !== \\"undefined\\" ? require : a)[b]
+  }) : x)(function(x) {
+    if (typeof require !== \\"undefined\\")
+      return require.apply(this, arguments);
+    throw Error('Dynamic require of \\"' + x + '\\" is not supported');
+  });
+
+  // tests/fixtures/input/polyfill.ts
+  var import_util = __require(\\"util\\");
+  var data = {
+    name: \\"esbuild\\"
+  };
+  var result = (0, import_util.inspect)(data, { depth: 0, colors: true });
+  console.log(result);
+})();
+"
+`;
+
+exports[`Polyfill Test > GIVEN a file that imports a node builtin and opts into an empty polyfill THEN provide an empty module 1`] = `
+"\\"use strict\\";
+(() => {
+  var __create = Object.create;
+  var __defProp = Object.defineProperty;
+  var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+  var __getOwnPropNames = Object.getOwnPropertyNames;
+  var __getProtoOf = Object.getPrototypeOf;
+  var __hasOwnProp = Object.prototype.hasOwnProperty;
+  var __commonJS = (cb, mod) => function __require() {
+    return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+  };
+  var __copyProps = (to, from, except, desc) => {
+    if (from && typeof from === \\"object\\" || typeof from === \\"function\\") {
+      for (let key of __getOwnPropNames(from))
+        if (!__hasOwnProp.call(to, key) && key !== except)
+          __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+    }
+    return to;
+  };
+  var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+    // If the importer is in node compatibility mode or this is not an ESM
+    // file that has been converted to a CommonJS file using a Babel-
+    // compatible transform (i.e. \\"__esModule\\" has not been set), then set
+    // \\"default\\" to the CommonJS \\"module.exports\\" for node compatibility.
+    isNodeMode || !mod || !mod.__esModule ? __defProp(target, \\"default\\", { value: mod, enumerable: true }) : target,
+    mod
+  ));
+
+  // node-modules-polyfills-empty:util
+  var require_util = __commonJS({
+    \\"node-modules-polyfills-empty:util\\"(exports, module) {
+      module.exports = {};
+    }
+  });
+
+  // tests/fixtures/input/polyfill.ts
+  var import_util = __toESM(require_util());
+  var data = {
+    name: \\"esbuild\\"
+  };
+  var result = (0, import_util.inspect)(data, { depth: 0, colors: true });
+  console.log(result);
+})();
+"
+`;
+
 exports[`Polyfill Test > GIVEN a file that imports a node builtin and opts into polyfill THEN polyfill it 1`] = `
 "\\"use strict\\";
 (() => {

--- a/tests/scenarios/polyfill.test.ts
+++ b/tests/scenarios/polyfill.test.ts
@@ -33,9 +33,29 @@ describe('Polyfill Test', () => {
 		await assertFileContent('./fixtures/output/polyfill.js');
 	});
 
+	test('GIVEN a file that imports a node builtin and opts into an empty polyfill THEN provide an empty module', async () => {
+		const config = createConfig({
+			modules: { util: 'empty' },
+		});
+
+		await esbuild.build(config);
+
+		await assertFileContent('./fixtures/output/polyfill.js');
+	});
+
 	test("GIVEN a file that imports a node builtin and doesn't opt into polyfill THEN don't polyfill it", async () => {
 		const config = createConfig({
 			modules: [],
+		});
+
+		await esbuild.build(config);
+
+		await assertFileContent('./fixtures/output/polyfill.js');
+	});
+
+	test("GIVEN a file that imports a node builtin and explicitly opts out of polyfill THEN don't polyfill it", async () => {
+		const config = createConfig({
+			modules: { util: false },
 		});
 
 		await esbuild.build(config);


### PR DESCRIPTION
I've been investigating issues some Remix users have had since we migrated from [esbuild-plugin-polyfill-node](https://github.com/cyco130/esbuild-plugin-polyfill-node).

One issue is that the `fs` polyfill is throwing an error when building for Cloudflare since it sets up a file system watcher as a top-level side effect:

```
service core:user:worker: Uncaught Error: Some functionality, such as asynchronous I/O, timeouts, and generating random values, can only be performed while handling a request.
```

What's interesting is this wasn't happening with our old polyfill setup even though it was also built on JSPM browser polyfills. It turns out that previously the `fs` polyfill was actually an empty module by default (among others): https://github.com/cyco130/esbuild-plugin-polyfill-node/blob/9afcb6abaf9062a15daaffce9a14e478b365139c/src/index.ts#L143-L149. I can reproduce the same error with our old polyfills if I explicitly enable the `fs` polyfill.

In order to support this scenario, this PR extends the `modules` option to support an object that can optionally configure empty polyfills, e.g.

```js
nodeModulesPolyfillPlugin({
  modules: {
    fs: 'empty',
    crypto: true,
  }
})
```

**Status and versioning classification:**

- Code changes have been tested and working fine, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
