### PR TITLE
fix: mark polyfills as side-effect free

### DIFF
--- a/src/lib/plugin.ts
+++ b/src/lib/plugin.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { getCachedPolyfillContent, getCachedPolyfillPath } from './polyfill.js';
 import { escapeRegex, commonJsTemplate, normalizeNodeBuiltinPath } from './utils/util.js';
 
-import type { OnResolveArgs, Plugin } from 'esbuild';
+import type { OnResolveArgs, OnResolveResult, Plugin } from 'esbuild';
 import type esbuild from 'esbuild';
 
 const NAME = 'node-modules-polyfills';
@@ -108,7 +108,7 @@ export const nodeModulesPolyfillPlugin = (options: NodePolyfillsOptions = {}): P
 					.join('|')})$`,
 			);
 
-			const resolver = async (args: OnResolveArgs) => {
+			const resolver = async (args: OnResolveArgs): Promise<OnResolveResult | undefined> => {
 				const moduleName = normalizeNodeBuiltinPath(args.path);
 
 				if (!modules[moduleName]) {
@@ -119,6 +119,7 @@ export const nodeModulesPolyfillPlugin = (options: NodePolyfillsOptions = {}): P
 					return {
 						namespace: emptyNamespace,
 						path: args.path,
+						sideEffects: false,
 					};
 				}
 
@@ -134,6 +135,7 @@ export const nodeModulesPolyfillPlugin = (options: NodePolyfillsOptions = {}): P
 				return {
 					namespace: isCommonjs ? commonjsNamespace : namespace,
 					path: args.path,
+					sideEffects: false,
 				};
 			};
 

--- a/tests/fixtures/input/unusedImport.ts
+++ b/tests/fixtures/input/unusedImport.ts
@@ -1,0 +1,3 @@
+import { message } from './unusedImport/exports';
+
+console.log(message);

--- a/tests/fixtures/input/unusedImport/exports.ts
+++ b/tests/fixtures/input/unusedImport/exports.ts
@@ -1,0 +1,3 @@
+export const message = 'Hello world';
+
+export { default as assertStrict } from 'node:assert/strict';

--- a/tests/scenarios/__snapshots__/unusedImport.test.ts.snap
+++ b/tests/scenarios/__snapshots__/unusedImport.test.ts.snap
@@ -1,0 +1,10 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Unused Import Test > GIVEN a file that imports from a module exporting a node builtin and does not use it THEN it should be removed by esbuild 1`] = `
+"// tests/fixtures/input/unusedImport/exports.ts
+var message = \\"Hello world\\";
+
+// tests/fixtures/input/unusedImport.ts
+console.log(message);
+"
+`;

--- a/tests/scenarios/unusedImport.test.ts
+++ b/tests/scenarios/unusedImport.test.ts
@@ -1,0 +1,25 @@
+import esbuild, { type BuildOptions } from 'esbuild';
+
+import { assertFileContent, buildAbsolutePath, createEsbuildConfig } from '../util';
+
+import type { NodePolyfillsOptions } from '../../dist';
+
+function createConfig(pluginOptions?: NodePolyfillsOptions): BuildOptions {
+	return createEsbuildConfig(
+		{
+			format: 'esm',
+			entryPoints: [buildAbsolutePath('./fixtures/input/unusedImport.ts')],
+		},
+		pluginOptions,
+	);
+}
+
+describe('Unused Import Test', () => {
+	test('GIVEN a file that imports from a module exporting a node builtin and does not use it THEN it should be removed by esbuild', async () => {
+		const config = createConfig();
+
+		await esbuild.build(config);
+
+		await assertFileContent('./fixtures/output/unusedImport.js');
+	});
+});


### PR DESCRIPTION
This fixes an issue that was raised against Remix (https://github.com/remix-run/remix/issues/7134) where polyfills weren't being tree-shaken correctly.

**Status and versioning classification:**
- Code changes have been tested and working fine, or there are no code changes
