### PR TITLE
fix: use empty polyfill if browser field is false

### DIFF
--- a/src/lib/plugin.ts
+++ b/src/lib/plugin.ts
@@ -125,7 +125,20 @@ export const nodeModulesPolyfillPlugin = (options: NodePolyfillsOptions = {}): P
 				if (initialOptions.platform === 'browser') {
 					const packageJson = await loadPackageJSON(args.resolveDir);
 					const browserFieldValue = packageJson?.browser?.[args.path];
-					if (browserFieldValue !== undefined) return;
+
+					// This is here to support consumers who have used the
+					// "external" option to exclude all Node builtins (e.g.
+					// Remix v1 does this), otherwise the import/require is left
+					// in the output and throws an error at runtime. Ideally we
+					// would just return undefined for any browser field value,
+					// and we can safely switch to this in a major version.
+					if (browserFieldValue === false) {
+						return emptyResult;
+					}
+
+					if (browserFieldValue !== undefined) {
+						return;
+					}
 				}
 
 				const moduleName = normalizeNodeBuiltinPath(args.path);

--- a/tests/scenarios/__snapshots__/browserFieldFalse.test.ts.snap
+++ b/tests/scenarios/__snapshots__/browserFieldFalse.test.ts.snap
@@ -29,9 +29,10 @@ exports[`Browser Field False Test > GIVEN a file in a browser target build that 
     mod
   ));
 
-  // (disabled):constants
+  // node-modules-polyfills-empty:constants
   var require_constants = __commonJS({
-    \\"(disabled):constants\\"() {
+    \\"node-modules-polyfills-empty:constants\\"(exports, module) {
+      module.exports = {};
     }
   });
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes https://github.com/remix-run/remix/issues/7095#issuecomment-1690590689.

The [change you made to made to the browser field PR](https://github.com/imranbarbhuiya/esbuild-plugins-node-modules-polyfill/pull/150#discussion_r1302791140) is actually the way I originally wrote it too, but in my local testing it caused the issue raised in the comment above. Sorry for not calling this out in the original PR.

As noted in the comment, I prefer the way you wrote it, but since it's a breaking change for Remix v1 consumers, I'm hoping we can hold off on this until a major release.

**Status and versioning classification:**

- Code changes have been tested and working fine, or there are no code changes