### PR TITLE
feat: allow modules to be marked as errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,38 @@ build({
 });
 ```
 
+Optionally fail the build when certain modules are used (note that the `write` build option must be `false` to support this):
+
+```ts
+import { nodeModulesPolyfillPlugin } from 'esbuild-plugins-node-modules-polyfill';
+import { build } from 'esbuild';
+const buildResult = await build({
+	write: false,
+	plugins: [nodeModulesPolyfillPlugin({
+		modules: {
+			crypto: 'error',
+			path: true,
+		},
+	})],
+});
+```
+
+Optionally fail the build when a module is not polyfilled or configured (note that the `write` build option must be `false` to support this):
+
+```ts
+import { nodeModulesPolyfillPlugin } from 'esbuild-plugins-node-modules-polyfill';
+import { build } from 'esbuild';
+const buildResult = await build({
+	write: false,
+	plugins: [nodeModulesPolyfillPlugin({
+		fallback: 'error',
+		modules: {
+			path: true,
+		}
+	})],
+});
+```
+
 ## Buy me some doughnuts
 
 If you want to support me by donating, you can do so by using any of the following methods. Thank you very much in advance!

--- a/tests/fixtures/input/errorFallback.ts
+++ b/tests/fixtures/input/errorFallback.ts
@@ -1,0 +1,7 @@
+import * as crypto from 'node:crypto';
+import * as path from 'node:path';
+import * as trace_events from 'node:trace_events';
+
+console.log(crypto);
+console.log(trace_events);
+console.log(path);

--- a/tests/fixtures/input/errorModules.ts
+++ b/tests/fixtures/input/errorModules.ts
@@ -1,0 +1,7 @@
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+console.log(crypto);
+console.log(fs);
+console.log(path);

--- a/tests/scenarios/errorFallback.test.ts
+++ b/tests/scenarios/errorFallback.test.ts
@@ -1,0 +1,150 @@
+import esbuild, { type BuildOptions, type Message } from 'esbuild';
+
+import { buildAbsolutePath, createEsbuildConfig } from '../util';
+
+import type { NodePolyfillsOptions } from '../../dist';
+
+function createConfig(buildOptions: Omit<BuildOptions, 'plugins'>, pluginOptions?: NodePolyfillsOptions): BuildOptions {
+	return createEsbuildConfig(
+		{
+			format: 'iife',
+			entryPoints: [buildAbsolutePath('./fixtures/input/errorFallback.ts')],
+			...buildOptions,
+		},
+		pluginOptions,
+	);
+}
+
+describe('Error Fallback Test', () => {
+	test('GIVEN a file that imports a node builtins that are defined as errors in the modules config THEN fail the build with appropriate error messages', async () => {
+		const config = createConfig(
+			{
+				write: false,
+			},
+			{
+				fallback: 'error',
+				modules: {
+					path: true,
+					trace_events: true, // This will be a fallback since it's not polyfilled
+				},
+			},
+		);
+
+		let errors: Message[] | undefined;
+
+		try {
+			await esbuild.build(config);
+		} catch (error) {
+			// @ts-expect-error error isn't type safe
+			errors = error.errors;
+		}
+
+		expect(errors?.map((error) => error.text)).toMatchInlineSnapshot(`
+			[
+			  "Module \\"node:crypto\\" is not polyfilled, imported by \\"tests/fixtures/input/errorFallback.ts\\"",
+			  "Module \\"node:trace_events\\" is not polyfilled, imported by \\"tests/fixtures/input/errorFallback.ts\\"",
+			]
+		`);
+		expect(errors).toHaveLength(2);
+	});
+
+	test('GIVEN outfile maps to a .mjs file THEN fail the build with appropriate error messages', async () => {
+		const config = createConfig(
+			{
+				write: false,
+				outdir: undefined,
+				outfile: 'out.mjs',
+			},
+			{
+				fallback: 'error',
+				modules: {
+					path: true,
+					trace_events: true, // This will be a fallback since it's not polyfilled
+				},
+			},
+		);
+
+		let errors: Message[] | undefined;
+
+		try {
+			await esbuild.build(config);
+		} catch (error) {
+			// @ts-expect-error error isn't type safe
+			errors = error.errors;
+		}
+
+		expect(errors?.map((error) => error.text)).toMatchInlineSnapshot(`
+			[
+			  "Module \\"node:crypto\\" is not polyfilled, imported by \\"tests/fixtures/input/errorFallback.ts\\"",
+			  "Module \\"node:trace_events\\" is not polyfilled, imported by \\"tests/fixtures/input/errorFallback.ts\\"",
+			]
+		`);
+		expect(errors).toHaveLength(2);
+	});
+
+	test('GIVEN outExtension maps .js to .mjs THEN fail the build with appropriate error messages', async () => {
+		const config = createConfig(
+			{
+				write: false,
+				outExtension: {
+					'.js': '.mjs',
+				},
+			},
+			{
+				fallback: 'error',
+				modules: {
+					path: true,
+					trace_events: true, // This will be a fallback since it's not polyfilled
+				},
+			},
+		);
+
+		let errors: Message[] | undefined;
+
+		try {
+			await esbuild.build(config);
+		} catch (error) {
+			// @ts-expect-error error isn't type safe
+			errors = error.errors;
+		}
+
+		expect(errors?.map((error) => error.text)).toMatchInlineSnapshot(`
+			[
+			  "Module \\"node:crypto\\" is not polyfilled, imported by \\"tests/fixtures/input/errorFallback.ts\\"",
+			  "Module \\"node:trace_events\\" is not polyfilled, imported by \\"tests/fixtures/input/errorFallback.ts\\"",
+			]
+		`);
+		expect(errors).toHaveLength(2);
+	});
+
+	test('GIVEN write mode is enabled when using error polyfill fallback THEN fail the build with appropriate error messages', async () => {
+		const config = createConfig(
+			{
+				write: true,
+			},
+			{
+				fallback: 'error',
+				modules: {
+					path: true,
+					trace_events: true, // This will be a fallback since it's not polyfilled
+				},
+			},
+		);
+
+		let errors: Message[] | undefined;
+
+		try {
+			await esbuild.build(config);
+		} catch (error) {
+			// @ts-expect-error error isn't type safe
+			errors = error.errors;
+		}
+
+		expect(errors?.map((error) => error.text)).toMatchInlineSnapshot(`
+			[
+			  "The \\"write\\" build option must be set to false when using the \\"error\\" polyfill type",
+			]
+		`);
+		expect(errors).toHaveLength(1);
+	});
+});

--- a/tests/scenarios/errorModules.test.ts
+++ b/tests/scenarios/errorModules.test.ts
@@ -1,0 +1,153 @@
+import esbuild, { type BuildOptions, type Message } from 'esbuild';
+
+import { buildAbsolutePath, createEsbuildConfig } from '../util';
+
+import type { NodePolyfillsOptions } from '../../dist';
+
+function createConfig(
+	buildOptions: Pick<BuildOptions, 'write' | 'outExtension'>,
+	pluginOptions?: NodePolyfillsOptions,
+): BuildOptions {
+	return createEsbuildConfig(
+		{
+			format: 'iife',
+			entryPoints: [buildAbsolutePath('./fixtures/input/errorModules.ts')],
+			...buildOptions,
+		},
+		pluginOptions,
+	);
+}
+
+describe('Error Modules Test', () => {
+	test('GIVEN a file that imports a node builtins that are defined as errors in the modules config THEN fail the build with appropriate error messages', async () => {
+		const config = createConfig(
+			{
+				write: false,
+			},
+			{
+				modules: {
+					crypto: 'error',
+					fs: 'error',
+					path: true,
+				},
+			},
+		);
+
+		let errors: Message[] | undefined;
+
+		try {
+			await esbuild.build(config);
+		} catch (error) {
+			// @ts-expect-error error isn't type safe
+			errors = error.errors;
+		}
+
+		expect(errors?.map((error) => error.text)).toMatchInlineSnapshot(`
+			[
+			  "Module \\"node:crypto\\" is not polyfilled, imported by \\"tests/fixtures/input/errorModules.ts\\"",
+			  "Module \\"node:fs\\" is not polyfilled, imported by \\"tests/fixtures/input/errorModules.ts\\"",
+			]
+		`);
+		expect(errors).toHaveLength(2);
+	});
+
+	test('GIVEN outfile maps to a .mjs file THEN fail the build with appropriate error messages', async () => {
+		const config = createConfig(
+			{
+				write: false,
+				outdir: undefined,
+				outfile: 'out.mjs',
+			},
+			{
+				modules: {
+					crypto: 'error',
+					fs: 'error',
+					path: true,
+				},
+			},
+		);
+
+		let errors: Message[] | undefined;
+
+		try {
+			await esbuild.build(config);
+		} catch (error) {
+			// @ts-expect-error error isn't type safe
+			errors = error.errors;
+		}
+
+		expect(errors?.map((error) => error.text)).toMatchInlineSnapshot(`
+			[
+			  "Module \\"node:crypto\\" is not polyfilled, imported by \\"tests/fixtures/input/errorModules.ts\\"",
+			  "Module \\"node:fs\\" is not polyfilled, imported by \\"tests/fixtures/input/errorModules.ts\\"",
+			]
+		`);
+		expect(errors).toHaveLength(2);
+	});
+
+	test('GIVEN outExtension maps .js to .mjs THEN fail the build with appropriate error messages', async () => {
+		const config = createConfig(
+			{
+				write: false,
+				outExtension: {
+					'.js': '.mjs',
+				},
+			},
+			{
+				modules: {
+					crypto: 'error',
+					fs: 'error',
+					path: true,
+				},
+			},
+		);
+
+		let errors: Message[] | undefined;
+
+		try {
+			await esbuild.build(config);
+		} catch (error) {
+			// @ts-expect-error error isn't type safe
+			errors = error.errors;
+		}
+
+		expect(errors?.map((error) => error.text)).toMatchInlineSnapshot(`
+			[
+			  "Module \\"node:crypto\\" is not polyfilled, imported by \\"tests/fixtures/input/errorModules.ts\\"",
+			  "Module \\"node:fs\\" is not polyfilled, imported by \\"tests/fixtures/input/errorModules.ts\\"",
+			]
+		`);
+		expect(errors).toHaveLength(2);
+	});
+
+	test('GIVEN write mode is enabled when using error polyfill modules THEN fail the build with appropriate error messages', async () => {
+		const config = createConfig(
+			{
+				write: true,
+			},
+			{
+				modules: {
+					crypto: 'error',
+					fs: 'error',
+					path: true,
+				},
+			},
+		);
+
+		let errors: Message[] | undefined;
+
+		try {
+			await esbuild.build(config);
+		} catch (error) {
+			// @ts-expect-error error isn't type safe
+			errors = error.errors;
+		}
+
+		expect(errors?.map((error) => error.text)).toMatchInlineSnapshot(`
+			[
+			  "The \\"write\\" build option must be set to false when using the \\"error\\" polyfill type",
+			]
+		`);
+		expect(errors).toHaveLength(1);
+	});
+});

--- a/tests/util.ts
+++ b/tests/util.ts
@@ -7,14 +7,14 @@ import { nodeModulesPolyfillPlugin, type NodePolyfillsOptions } from '../dist/in
 import type { BuildOptions } from 'esbuild';
 
 export function createEsbuildConfig(
-	buildOptions: BuildOptions,
+	buildOptions: Omit<BuildOptions, 'plugins'>,
 	nodePolyfillsOptions?: NodePolyfillsOptions,
 ): BuildOptions {
 	return {
 		platform: 'node',
-		...buildOptions,
 		outdir: buildAbsolutePath('./fixtures/output'),
 		bundle: true,
+		...buildOptions,
 		plugins: [nodeModulesPolyfillPlugin(nodePolyfillsOptions)],
 	};
 }


### PR DESCRIPTION
This adds an `error` module type so that Node built-ins can be marked as errors if they're present in the final output.

I've described this in a comment in the code, but this is done by scanning the generated code so that unused modules can be part of the module graph. This way it's only an error if they're not tree shaken.

This is useful in the context of Remix because we have Node built-ins in the module graph that may never be used on the client. This is due to the way route files contain both server and client code. In this case the `fallback` option is super useful because I can break the Remix browser build if an unpolyfilled module is detected in the output, whereas our `v2` branch currently falls back to an empty module which is a runtime error. This approach is much nicer for us.

**Status and versioning classification:**

- Code changes have been tested and working fine, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
