### PR TITLE
feat: support custom error formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,36 @@ const buildResult = await build({
 });
 ```
 
+### Provide a custom error formatter for when a module is not polyfilled or configured:
+
+Return an esbuild `PartialMessage` object from the `formatError` function to override any properties of the default error message.
+
+> **Warning**
+> The `write` option in `esbuild` must be `false` to support this.
+
+```ts
+import { nodeModulesPolyfillPlugin } from 'esbuild-plugins-node-modules-polyfill';
+import { build } from 'esbuild';
+const buildResult = await build({
+	write: false,
+	plugins: [
+		nodeModulesPolyfillPlugin({
+			fallback: 'error',
+			modules: {
+				path: true,
+			},
+			formatError({ moduleName, importer, polyfillExists }) {
+				return {
+					text: polyfillExists
+						? `Polyfill has not been configured for "${moduleName}", imported by "${importer}"`
+						: `Polyfill does not exist for "${moduleName}", imported by "${importer}"`
+				};
+			}
+		}),
+	],
+});
+```
+
 ## Buy me some doughnuts
 
 If you want to support me by donating, you can do so by using any of the following methods. Thank you very much in advance!

--- a/tests/scenarios/errorFallback.test.ts
+++ b/tests/scenarios/errorFallback.test.ts
@@ -41,8 +41,70 @@ describe('Error Fallback Test', () => {
 
 		expect(errors?.map((error) => error.text)).toMatchInlineSnapshot(`
 			[
-			  "Module \\"node:crypto\\" is not polyfilled, imported by \\"tests/fixtures/input/errorFallback.ts\\"",
-			  "Module \\"node:trace_events\\" is not polyfilled, imported by \\"tests/fixtures/input/errorFallback.ts\\"",
+			  "Polyfill has not been configured for \\"node:crypto\\", imported by \\"tests/fixtures/input/errorFallback.ts\\"",
+			  "Polyfill does not exist for \\"node:trace_events\\", imported by \\"tests/fixtures/input/errorFallback.ts\\"",
+			]
+		`);
+		expect(errors).toHaveLength(2);
+	});
+
+	test('GIVEN an error formatter has been provided THEN use the custom errors instead', async () => {
+		const config = createConfig(
+			{
+				write: false,
+			},
+			{
+				fallback: 'error',
+				formatError(args) {
+					return {
+						notes: [{ text: 'This is a custom note' }],
+						text: `args: ${JSON.stringify(args)}`,
+					};
+				},
+				modules: {
+					path: true,
+					trace_events: true, // This will be a fallback since it's not polyfilled
+				},
+			},
+		);
+
+		let errors: Message[] | undefined;
+
+		try {
+			await esbuild.build(config);
+		} catch (error) {
+			// @ts-expect-error error isn't type safe
+			errors = error.errors;
+		}
+
+		expect(errors).toMatchInlineSnapshot(`
+			[
+			  {
+			    "detail": -1,
+			    "id": "",
+			    "location": null,
+			    "notes": [
+			      {
+			        "location": null,
+			        "text": "This is a custom note",
+			      },
+			    ],
+			    "pluginName": "node-modules-polyfills",
+			    "text": "args: {\\"moduleName\\":\\"node:crypto\\",\\"importer\\":\\"tests/fixtures/input/errorFallback.ts\\",\\"polyfillExists\\":true}",
+			  },
+			  {
+			    "detail": -1,
+			    "id": "",
+			    "location": null,
+			    "notes": [
+			      {
+			        "location": null,
+			        "text": "This is a custom note",
+			      },
+			    ],
+			    "pluginName": "node-modules-polyfills",
+			    "text": "args: {\\"moduleName\\":\\"node:trace_events\\",\\"importer\\":\\"tests/fixtures/input/errorFallback.ts\\",\\"polyfillExists\\":false}",
+			  },
 			]
 		`);
 		expect(errors).toHaveLength(2);
@@ -75,8 +137,8 @@ describe('Error Fallback Test', () => {
 
 		expect(errors?.map((error) => error.text)).toMatchInlineSnapshot(`
 			[
-			  "Module \\"node:crypto\\" is not polyfilled, imported by \\"tests/fixtures/input/errorFallback.ts\\"",
-			  "Module \\"node:trace_events\\" is not polyfilled, imported by \\"tests/fixtures/input/errorFallback.ts\\"",
+			  "Polyfill has not been configured for \\"node:crypto\\", imported by \\"tests/fixtures/input/errorFallback.ts\\"",
+			  "Polyfill does not exist for \\"node:trace_events\\", imported by \\"tests/fixtures/input/errorFallback.ts\\"",
 			]
 		`);
 		expect(errors).toHaveLength(2);
@@ -110,8 +172,8 @@ describe('Error Fallback Test', () => {
 
 		expect(errors?.map((error) => error.text)).toMatchInlineSnapshot(`
 			[
-			  "Module \\"node:crypto\\" is not polyfilled, imported by \\"tests/fixtures/input/errorFallback.ts\\"",
-			  "Module \\"node:trace_events\\" is not polyfilled, imported by \\"tests/fixtures/input/errorFallback.ts\\"",
+			  "Polyfill has not been configured for \\"node:crypto\\", imported by \\"tests/fixtures/input/errorFallback.ts\\"",
+			  "Polyfill does not exist for \\"node:trace_events\\", imported by \\"tests/fixtures/input/errorFallback.ts\\"",
 			]
 		`);
 		expect(errors).toHaveLength(2);

--- a/tests/scenarios/errorModules.test.ts
+++ b/tests/scenarios/errorModules.test.ts
@@ -44,8 +44,70 @@ describe('Error Modules Test', () => {
 
 		expect(errors?.map((error) => error.text)).toMatchInlineSnapshot(`
 			[
-			  "Module \\"node:crypto\\" is not polyfilled, imported by \\"tests/fixtures/input/errorModules.ts\\"",
-			  "Module \\"node:fs\\" is not polyfilled, imported by \\"tests/fixtures/input/errorModules.ts\\"",
+			  "Polyfill has not been configured for \\"node:crypto\\", imported by \\"tests/fixtures/input/errorModules.ts\\"",
+			  "Polyfill has not been configured for \\"node:fs\\", imported by \\"tests/fixtures/input/errorModules.ts\\"",
+			]
+		`);
+		expect(errors).toHaveLength(2);
+	});
+
+	test('GIVEN an error formatter has been provided THEN use the custom errors instead', async () => {
+		const config = createConfig(
+			{
+				write: false,
+			},
+			{
+				modules: {
+					crypto: 'error',
+					fs: 'error',
+					path: true,
+				},
+				formatError(args) {
+					return {
+						notes: [{ text: 'This is a custom note' }],
+						text: `args: ${JSON.stringify(args)}`,
+					};
+				},
+			},
+		);
+
+		let errors: Message[] | undefined;
+
+		try {
+			await esbuild.build(config);
+		} catch (error) {
+			// @ts-expect-error error isn't type safe
+			errors = error.errors;
+		}
+
+		expect(errors).toMatchInlineSnapshot(`
+			[
+			  {
+			    "detail": -1,
+			    "id": "",
+			    "location": null,
+			    "notes": [
+			      {
+			        "location": null,
+			        "text": "This is a custom note",
+			      },
+			    ],
+			    "pluginName": "node-modules-polyfills",
+			    "text": "args: {\\"moduleName\\":\\"node:crypto\\",\\"importer\\":\\"tests/fixtures/input/errorModules.ts\\",\\"polyfillExists\\":true}",
+			  },
+			  {
+			    "detail": -1,
+			    "id": "",
+			    "location": null,
+			    "notes": [
+			      {
+			        "location": null,
+			        "text": "This is a custom note",
+			      },
+			    ],
+			    "pluginName": "node-modules-polyfills",
+			    "text": "args: {\\"moduleName\\":\\"node:fs\\",\\"importer\\":\\"tests/fixtures/input/errorModules.ts\\",\\"polyfillExists\\":true}",
+			  },
 			]
 		`);
 		expect(errors).toHaveLength(2);
@@ -78,8 +140,8 @@ describe('Error Modules Test', () => {
 
 		expect(errors?.map((error) => error.text)).toMatchInlineSnapshot(`
 			[
-			  "Module \\"node:crypto\\" is not polyfilled, imported by \\"tests/fixtures/input/errorModules.ts\\"",
-			  "Module \\"node:fs\\" is not polyfilled, imported by \\"tests/fixtures/input/errorModules.ts\\"",
+			  "Polyfill has not been configured for \\"node:crypto\\", imported by \\"tests/fixtures/input/errorModules.ts\\"",
+			  "Polyfill has not been configured for \\"node:fs\\", imported by \\"tests/fixtures/input/errorModules.ts\\"",
 			]
 		`);
 		expect(errors).toHaveLength(2);
@@ -98,6 +160,7 @@ describe('Error Modules Test', () => {
 					crypto: 'error',
 					fs: 'error',
 					path: true,
+					trace_events: 'error', // This doesn't have a polyfill available
 				},
 			},
 		);
@@ -113,8 +176,8 @@ describe('Error Modules Test', () => {
 
 		expect(errors?.map((error) => error.text)).toMatchInlineSnapshot(`
 			[
-			  "Module \\"node:crypto\\" is not polyfilled, imported by \\"tests/fixtures/input/errorModules.ts\\"",
-			  "Module \\"node:fs\\" is not polyfilled, imported by \\"tests/fixtures/input/errorModules.ts\\"",
+			  "Polyfill has not been configured for \\"node:crypto\\", imported by \\"tests/fixtures/input/errorModules.ts\\"",
+			  "Polyfill has not been configured for \\"node:fs\\", imported by \\"tests/fixtures/input/errorModules.ts\\"",
 			]
 		`);
 		expect(errors).toHaveLength(2);


### PR DESCRIPTION
This PR adds a new `formatError` option so that consumers can customise the error messages when an `error` module is detected. This is useful in the context of a tool like Remix where we'll want to give our consumers more Remix-specific advice for how to fix the error since they don't have access to this esbuild plugin directly.

I've also improved the error messaging for when a module doesn't have a polyfill available. Without this we'd end up instructing our consumers to enable the polyfill, only for the polyfill to fail.

**Status and versioning classification:**

- Code changes have been tested and working fine, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
