### PR TITLE
test: ensure tree-shaken modules avoid fallback

### DIFF
--- a/tests/fixtures/input/errorFallback/errorFallback.ts
+++ b/tests/fixtures/input/errorFallback/errorFallback.ts
@@ -2,6 +2,11 @@ import * as crypto from 'node:crypto';
 import * as path from 'node:path';
 import * as trace_events from 'node:trace_events';
 
+// Ensure unused polyfills don't trigger the fallback
+import { message } from './unusedPolyfill';
+
 console.log(crypto);
 console.log(trace_events);
 console.log(path);
+
+console.log(message);

--- a/tests/fixtures/input/errorFallback/unusedPolyfill.ts
+++ b/tests/fixtures/input/errorFallback/unusedPolyfill.ts
@@ -1,0 +1,7 @@
+export const message = 'Hello world';
+
+// This polyfill has not been configured, so typically this would trigger the
+// fallback. However, this will be tree-shaken away since it's not used, so we
+// want to ensure that it doesn't trigger the fallback. The error message in the
+// test should NOT contain a reference to this Node builtin.
+export { default as assertStrict } from 'node:assert/strict';

--- a/tests/scenarios/errorFallback.test.ts
+++ b/tests/scenarios/errorFallback.test.ts
@@ -8,7 +8,7 @@ function createConfig(buildOptions: Omit<BuildOptions, 'plugins'>, pluginOptions
 	return createEsbuildConfig(
 		{
 			format: 'iife',
-			entryPoints: [buildAbsolutePath('./fixtures/input/errorFallback.ts')],
+			entryPoints: [buildAbsolutePath('./fixtures/input/errorFallback/errorFallback.ts')],
 			...buildOptions,
 		},
 		pluginOptions,
@@ -41,8 +41,8 @@ describe('Error Fallback Test', () => {
 
 		expect(errors?.map((error) => error.text)).toMatchInlineSnapshot(`
 			[
-			  "Polyfill has not been configured for \\"node:crypto\\", imported by \\"tests/fixtures/input/errorFallback.ts\\"",
-			  "Polyfill does not exist for \\"node:trace_events\\", imported by \\"tests/fixtures/input/errorFallback.ts\\"",
+			  "Polyfill has not been configured for \\"node:crypto\\", imported by \\"tests/fixtures/input/errorFallback/errorFallback.ts\\"",
+			  "Polyfill does not exist for \\"node:trace_events\\", imported by \\"tests/fixtures/input/errorFallback/errorFallback.ts\\"",
 			]
 		`);
 		expect(errors).toHaveLength(2);
@@ -90,7 +90,7 @@ describe('Error Fallback Test', () => {
 			      },
 			    ],
 			    "pluginName": "node-modules-polyfills",
-			    "text": "args: {\\"moduleName\\":\\"node:crypto\\",\\"importer\\":\\"tests/fixtures/input/errorFallback.ts\\",\\"polyfillExists\\":true}",
+			    "text": "args: {\\"moduleName\\":\\"node:crypto\\",\\"importer\\":\\"tests/fixtures/input/errorFallback/errorFallback.ts\\",\\"polyfillExists\\":true}",
 			  },
 			  {
 			    "detail": -1,
@@ -103,7 +103,7 @@ describe('Error Fallback Test', () => {
 			      },
 			    ],
 			    "pluginName": "node-modules-polyfills",
-			    "text": "args: {\\"moduleName\\":\\"node:trace_events\\",\\"importer\\":\\"tests/fixtures/input/errorFallback.ts\\",\\"polyfillExists\\":false}",
+			    "text": "args: {\\"moduleName\\":\\"node:trace_events\\",\\"importer\\":\\"tests/fixtures/input/errorFallback/errorFallback.ts\\",\\"polyfillExists\\":false}",
 			  },
 			]
 		`);
@@ -137,8 +137,8 @@ describe('Error Fallback Test', () => {
 
 		expect(errors?.map((error) => error.text)).toMatchInlineSnapshot(`
 			[
-			  "Polyfill has not been configured for \\"node:crypto\\", imported by \\"tests/fixtures/input/errorFallback.ts\\"",
-			  "Polyfill does not exist for \\"node:trace_events\\", imported by \\"tests/fixtures/input/errorFallback.ts\\"",
+			  "Polyfill has not been configured for \\"node:crypto\\", imported by \\"tests/fixtures/input/errorFallback/errorFallback.ts\\"",
+			  "Polyfill does not exist for \\"node:trace_events\\", imported by \\"tests/fixtures/input/errorFallback/errorFallback.ts\\"",
 			]
 		`);
 		expect(errors).toHaveLength(2);
@@ -172,8 +172,8 @@ describe('Error Fallback Test', () => {
 
 		expect(errors?.map((error) => error.text)).toMatchInlineSnapshot(`
 			[
-			  "Polyfill has not been configured for \\"node:crypto\\", imported by \\"tests/fixtures/input/errorFallback.ts\\"",
-			  "Polyfill does not exist for \\"node:trace_events\\", imported by \\"tests/fixtures/input/errorFallback.ts\\"",
+			  "Polyfill has not been configured for \\"node:crypto\\", imported by \\"tests/fixtures/input/errorFallback/errorFallback.ts\\"",
+			  "Polyfill does not exist for \\"node:trace_events\\", imported by \\"tests/fixtures/input/errorFallback/errorFallback.ts\\"",
 			]
 		`);
 		expect(errors).toHaveLength(2);


### PR DESCRIPTION
I've updated the fallback fixture so that we also check that tree-shaken modules that would otherwise have triggered the error fallback are _not_ present in the error message. This would be pretty disruptive if this regressed in a Remix context so I thought it'd be a good idea to ensure this can't slip through.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
