### PR TITLE
docs: add modules to global polyfills usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ build({
 				process: true,
 				Buffer: true,
 			},
+			// You'll probably need to polyfill the modules too
+			// since the global polyfills import from them:
+			modules: {
+				process: true,
+				buffer: true,
+			},
 		}),
 	],
 });

--- a/README.md
+++ b/README.md
@@ -52,16 +52,13 @@ build({
 				process: true,
 				Buffer: true,
 			},
-			// You'll probably need to polyfill the modules too
-			// since the global polyfills import from them:
-			modules: {
-				process: true,
-				buffer: true,
-			},
 		}),
 	],
 });
 ```
+
+> **Note**
+> If you are utilizing the [`modules`][#configure-which-modules-to-polyfill] option, ensure that you include polyfills for the global modules you are using.
 
 ### Configure which modules to polyfill:
 


### PR DESCRIPTION
I noticed the docs are incomplete for global polyfills since they depend on the corresponding modules being present.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
