### PR TITLE
chore: correct `esbuild` peer dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 		"vitest": "^2.0.5"
 	},
 	"peerDependencies": {
-		"esbuild": ">=0.14.0 <=0.23.0"
+		"esbuild": ">=0.14.0 ^0.23.0"
 	},
 	"files": [
 		"dist/**/*.js*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2850,7 +2850,7 @@ __metadata:
     typescript: "npm:^5.5.4"
     vitest: "npm:^2.0.5"
   peerDependencies:
-    esbuild: ">=0.14.0 <=0.23.0"
+    esbuild: ">=0.14.0 ^0.23.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Correct `esbuild` peerDep requirement so version latest version is supported (0.23.1).

From PR template:

- Code changes have been tested and working fine, or there are no code changes
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
