### PR TITLE
chore: fix esbuild peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 		"vitest": "^2.1.1"
 	},
 	"peerDependencies": {
-		"esbuild": ">=0.14.0 ^0.23.0"
+		"esbuild": ">=0.14.0 <=0.23.x"
 	},
 	"files": [
 		"dist/**/*.js*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2922,7 +2922,7 @@ __metadata:
     typescript: "npm:^5.6.2"
     vitest: "npm:^2.1.1"
   peerDependencies:
-    esbuild: ">=0.14.0 ^0.23.0"
+    esbuild: ">=0.14.0 <=0.23.x"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
The change in https://github.com/imranbarbhuiya/esbuild-plugins-node-modules-polyfill/pull/275 was incorrect and causes peer dependency mismatch warnings for anyone not running esbuild 0.23.

```
WARN  Issues with peer dependencies found
packages/ui-app
├─┬ @remix-run/dev 2.12.0
│ └─┬ esbuild-plugins-node-modules-polyfill 1.6.6
│   └── ✕ unmet peer esbuild@">=0.14.0 ^0.23.0": found 0.17.6 in @remix-run/dev
```
